### PR TITLE
Handle error codes from node-influx client and propagate back to flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,12 @@ The function node generates sample points as follows:
 		}
 	];
 	return msg;
+
+
+### Handling Failed Reads and Writes
+Errors in the read and writes can be caught using the node-red `catch`
+node. Error information is availlable in the default `msg.error` as well
+as in the `msg.influx_error`. At time of writing this only includes the
+status code from the influx client. The `influx-read` node will
+always throw a `503`, whereas the write nodes throw more descriptive
+error codes as detailed in the [Influx API documentation](https://docs.influxdata.com/influxdb/v1.7/tools/api/#status-codes-and-responses-2).

--- a/influxdb.js
+++ b/influxdb.js
@@ -135,6 +135,9 @@ module.exports = function(RED) {
                 }
 
                 client.writePoints(points, writeOptions).catch(function(err) {
+                    msg.influx_error = {
+                        statusCode : err.res ? err.res.statusCode : 503
+                    }
                     node.error(err,msg);
                 });
             });
@@ -185,6 +188,9 @@ module.exports = function(RED) {
                 }
 
                 client.writePoints(msg.payload, writeOptions).catch(function(err) {
+                    msg.influx_error = {
+                        statusCode : err.res ? err.res.statusCode : 503
+                    }
                     node.error(err,msg);
                 });
             });
@@ -255,7 +261,10 @@ module.exports = function(RED) {
                     msg.payload = results;
                     node.send(msg);
                 }).catch(function (err) {
-                    node.error(err);
+                    msg.influx_error = {
+                        statusCode : err.res ? err.res.statusCode : 503
+                    }
+                    node.error(err, msg);
                 });
             });
         } else {


### PR DESCRIPTION
The error codes were not available in the error part of the `msg` since the `node-influx` cli has these defined inside their `err.res` which is not included in any `catch` nodes (from what I could tell).

I added the `statusCode` to the `msg` object in the catch of the three nodes so that users can handle the error codes in their flows.

I also bumped the version of lodash for #45 