### PR TITLE
Combined InfluxDB 1.8 Flux and 2.0 functionality into the existing nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # node-red-contrib-influxdb
 
-A <a href="http://nodered.org" target="_new">Node-RED</a> node to write and query data from an influxdb time series database.  These nodes use the <a href="https://www.npmjs.com/package/influx" target="_new">influxDB 1.x client</a> for node.js, specifically calling the **writePoints()**, and **query()** methods.  Currently these nodes can only communicate with one influxdb host.  These nodes do not support InfluxDb 2.0 yet.
+<a href="http://nodered.org" target="_new">Node-RED</a> nodes to write and query data from an influxdb time series database. 
+
+A first set of nodes, available under the category **InfluxDB 18** in the NR editor, use the <a href="https://www.npmjs.com/package/influx" target="_new">influxDB 1.x client</a> for node.js, specifically calling the **writePoints()**, and **query()** methods. Currently these nodes can only communicate with one influxdb host. These nodes are used for writing and querying data in InfluxDB 1.x to 1.8+.
+
+A second set of nodes, available under the category **InfluxDB 18 flux** in the NR editor, use the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new"> influxDB 2.0 API compatibility endpoints</a> available in the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for node.js. These nodes are used for writing and querying data with Flux in InfluxDB 1.8+.
+
+A third set of nodes, available as **InfluxDB 2** category, leverage the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for writing and querying data with Flux in InfluxDB 2.0.
 
 ## Prerequisites
 
-To run this you'll need access to an influxdb database version 1.x.  See the <a href="https://influxdb.com/" target="_new">influxdb site</a> for more information.  The last release of this node has been tested with InfluxDb 1.8.
+To run this you'll need access to an InfluxDB database version 1.x, 1.8+ or 2.0. See the <a href="https://influxdb.com/" target="_new">influxdb site</a> for more information. The last release of this node has been tested with InfluxDB 1.8 and 2.0.
 
 ## Install
 
@@ -13,9 +19,9 @@ Usually this is `~/.node-red` .
 
     npm install node-red-contrib-influxdb
 
-## Usage
+##  **Usage - InfluxDB 18**
 
-Nodes to write and query data from an influxdb time series database.
+Nodes to write and query data from an influxdb time series database. Supoorted versions from 1.x to 1.8.
 
 ### Input Node
 
@@ -171,3 +177,225 @@ this includes the HTTP status code returned from the influxdb server. The `influ
 node will always throw a `503`, whereas the write nodes will include other status codes
 as detailed in the 
 [Influx API documentation](https://docs.influxdata.com/influxdb/v1.8/tools/api/#status-codes-and-responses-2).
+
+## **Usage - InfluxDB 18 flux**
+
+Nodes to write and query data from an influxdb time series database using compatibility endpoints of the InfluxDB 2.0 client libraries for writing and querying data with Flux. Supoorted version is 1.8+.
+
+### Input Node
+
+Allows flux queries to be made to an influxdb time series database. The flux query can be specified in the configuration property or using the property **msg.query**. Setting it in the node will override the **msg.query**. The results will be returned in **msg.payload**.
+
+For example, here is a simple flow to query all of the points in the `test` database, where the query is in the configuration of the influxdb input node (copy and paste to your NR editor).
+
+    [{"id":"2c24bff8.5d5fb","type":"influxdb 1.8 flux in","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","query":"from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)","name":"","x":520,"y":300,"wires":[["9ec53e18.774c18"]]},{"id":"9ec53e18.774c18","type":"debug","z":"653805bf.2d2784","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":930,"y":300,"wires":[]},{"id":"a89497f8.4c509","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":140,"y":300,"wires":[["2c24bff8.5d5fb"]]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+This flow performs the same, but using a query in the msg.payload:
+
+    [{"id":"661fd96e.7691f8","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"topic":"","payload":"","payloadType":"date","x":160,"y":540,"wires":[["ce9462a5.eed9a8"]]},{"id":"ce9462a5.eed9a8","type":"function","z":"653805bf.2d2784","name":"simple query","func":"msg.query='from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)';\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":540,"wires":[["3d674774.6f9d08"]]},{"id":"f231bdfa.999e8","type":"debug","z":"653805bf.2d2784","name":"","active":true,"console":"false","complete":"false","x":810,"y":540,"wires":[]},{"id":"3d674774.6f9d08","type":"influxdb 1.8 flux in","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","query":"","name":"","x":580,"y":540,"wires":[["f231bdfa.999e8"]]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+The function node in this flow sets the `msg.query` property as follows:
+
+    msg.query='from(bucket: "test/autogen") |> range(start: -1m, stop: 1h)';
+    return msg;
+
+### Output Node
+
+Writes one or more points (fields and tags) to a measurement.
+
+The fields and tags to write are in ***msg.payload***. If the message is a string, number or boolean, it will be written as a single value to the specified measurement (field called *value*).
+
+For example, the following flow injects a single random field called `value` into the measurement `test` in the database `test` with the current timestamp.
+
+    [{"id":"120c5823.db609","type":"inject","z":"653805bf.2d2784","name":"","props":[{"p":"payload","v":"","vt":"date"},{"p":"topic","v":"","vt":"string"}],"repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":60,"wires":[["eb30f561.c70148"]]},{"id":"eb30f561.c70148","type":"function","z":"653805bf.2d2784","name":"Single Value","func":"msg.payload = Math.random() * 10;\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":330,"y":60,"wires":[["cad9f0d2.1463e8"]]},{"id":"cad9f0d2.1463e8","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":580,"y":60,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+The function node consists of the following:
+
+    msg.payload = Math.random() * 10;
+    return msg;
+
+If ***msg.payload*** is an object containing multiple properties, the fields will be written to the measurement.
+
+For example, the following flow injects four fields, `numValue`, `strValue`, `floatValue` and `booleanValue` into the same measurement with the current timestamp. A `time` field can be specified if the timestamp for the measurement is not the current one.
+
+    [{"id":"4fc65aec.2d88bc","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":120,"wires":[["b6d751d.392793"]]},{"id":"b6d751d.392793","type":"function","z":"653805bf.2d2784","name":"Fields","func":"msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":310,"y":120,"wires":[["207a1809.718b5"]]},{"id":"207a1809.718b5","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":580,"y":120,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+The function node in the flow above consists of the following:
+
+    msg.payload = {
+        numValue: 123.0,
+        strValue: "message",
+        floatValue: Math.random() * 10,
+        ooleanValue: true,
+        //time: new Date("2020-07-15T12:00:00Z")
+    }
+    return msg;
+
+If ***msg.payload*** is an array containing two objects, the first object will be written as the set of named fields and the second is the set of named tags.
+
+For example, the following simple flow injects three fields along with two tags, `tag1` and `tag2`:
+
+    [{"id":"e33df9a0.62473","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":180,"wires":[["d195b182.a4702"]]},{"id":"d195b182.a4702","type":"function","z":"653805bf.2d2784","name":"Fields and Tags","func":"msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":340,"y":180,"wires":[["bf4607a5.cc9a88"]]},{"id":"bf4607a5.cc9a88","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":610,"y":180,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+The function node consists of the following code:
+
+    msg.payload = [{
+        numValue: 12,
+        randomValue: Math.random() * 10,
+        strValue: "message2",
+        //time: new Date("2020-07-09T16:00:00Z")
+    },
+    {
+        tag1: "sensor1",
+        tag2: "device2"
+    }];
+    return msg;
+
+Finally, if ***msg.payload*** is an array of arrays, it will be written as a series of points containing fields and tags.
+
+For example, the following flow injects two points with timestamps specified.  
+
+    [{"id":"99251519.a7b3e8","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":240,"wires":[["1bf3451b.36b1bb"]]},{"id":"1bf3451b.36b1bb","type":"function","z":"653805bf.2d2784","name":"multiple readings","func":"msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":240,"wires":[["fd4b0034.d7eb7"]]},{"id":"fd4b0034.d7eb7","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":610,"y":240,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
+
+The function node in the above flow looks as follows:
+
+    msg.payload = [
+        [{
+            numValue: 10,
+            randomValue: Math.random() * 10,
+            strValue: "message1",
+            time: new Date("2020-07-16T13:00:02Z")
+        },
+        {
+            tag1: "sensor1",
+            tag2: "device2"
+        }],
+        [{
+            numValue: 20,
+            randomValue: Math.random() * 10,
+            strValue: "message2",
+            time: new Date("2020-07-16T13:00:03Z")
+        },
+        {
+            tag1: "sensor2",
+            tag2: "device1"
+        }]
+        ];
+    return msg;
+
+Note how timestamps are specified - the number of milliseconds since 1 January 1970 00:00:00 UTC. In this case do not forget to set "ms" in "Time Precision" of the influx out node.
+
+### Catching Failed Reads and Writes
+
+Errors in reads and writes can be caught using the node-red `catch` node as usual. Standard error information is availlable in the default `msg.error` field; additional information about the underlying error is in the `msg.influx_error` field. Currently, this includes the HTTP status code returned from the influxdb server.
+
+## **Usage - InfluxDB 2**
+
+Nodes to write and query data from an influxdb time series database using the InfluxDB 2.0 client libraries for writing and querying data with Flux. Supoorted version is 2.0.
+
+### Input Node
+
+Allows flux queries to be made to an influxdb time series database. The flux query can be specified in the configuration property or using the property **msg.query**. Setting it in the node will override the **msg.query**. The results will be returned in **msg.payload**.
+
+For example, here is a simple flow to query all of the points in the `test` bucket, where the query is in the configuration of the influxdb input node (copy and paste to your NR editor).
+
+    [{"id":"3e760db.d141d72","type":"debug","z":"c70ec85f.ffbc3","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":930,"y":300,"wires":[]},{"id":"6d054c00.b726dc","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":140,"y":300,"wires":[["de82c653.cd498"]]},{"id":"de82c653.cd498","type":"influxdb 2 in","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","query":"from(bucket: \"test\") |> range(start: -1m, stop: 1h)","name":"","x":500,"y":300,"wires":[["3e760db.d141d72"]]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+This flow performs the same, but using a query in the msg.payload:
+
+    [{"id":"e521a270.12701","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"topic":"","payload":"","payloadType":"date","x":160,"y":520,"wires":[["68210f4f.60f99"]]},{"id":"68210f4f.60f99","type":"function","z":"c70ec85f.ffbc3","name":"simple query","func":"msg.query='from(bucket: \"test\") |> range(start: -1m, stop: 1h)';\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":520,"wires":[["664bc03e.d3311"]]},{"id":"9a24c95c.a13a9","type":"debug","z":"c70ec85f.ffbc3","name":"","active":true,"console":"false","complete":"false","x":810,"y":520,"wires":[]},{"id":"664bc03e.d3311","type":"influxdb 2 in","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","query":"","name":"","x":580,"y":520,"wires":[["9a24c95c.a13a9"]]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+The function node in this flow sets the `msg.query` property as follows:
+
+    msg.query='from(bucket: "test") |> range(start: -1m, stop: 1h)';
+    return msg;
+
+### Output Node
+
+Writes one or more points (fields and tags) to a measurement.
+
+The fields and tags to write are in ***msg.payload***. If the message is a string, number or boolean, it will be written as a single value to the specified measurement (field called *value*).
+
+For example, the following flow injects a single random field called `value` into the measurement `test` in the bucket `test` and organisation `my-org` with the current timestamp.
+
+    [{"id":"d9f0ebfc.ecfec8","type":"inject","z":"c70ec85f.ffbc3","name":"","props":[{"p":"payload","v":"","vt":"date"},{"p":"topic","v":"","vt":"string"}],"repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":60,"wires":[["c555c3a0.204c58"]]},{"id":"c555c3a0.204c58","type":"function","z":"c70ec85f.ffbc3","name":"Single Value","func":"msg.payload = Math.random() * 10;\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":330,"y":60,"wires":[["f5a4befd.56d75"]]},{"id":"f5a4befd.56d75","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":60,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+The function node consists of the following:
+
+    msg.payload = Math.random() * 10;
+    return msg;
+
+If ***msg.payload*** is an object containing multiple properties, the fields will be written to the measurement.
+
+For example, the following flow injects four fields, `numValue`, `strValue`, `floatValue` and `booleanValue` into the same measurement with the current timestamp. A `time` field can be specified if the timestamp for the measurement is not the current one.
+
+    [{"id":"1606c311.639f3d","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":120,"wires":[["6fad44a5.d5f544"]]},{"id":"6fad44a5.d5f544","type":"function","z":"c70ec85f.ffbc3","name":"Fields","func":"msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":310,"y":120,"wires":[["a57b64be.670488"]]},{"id":"a57b64be.670488","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":120,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+The function node in the flow above consists of the following:
+
+    msg.payload = {
+        numValue: 123.0,
+        strValue: "message",
+        floatValue: Math.random() * 10,
+        ooleanValue: true,
+        //time: new Date("2020-07-15T12:00:00Z")
+    }
+    return msg;
+
+If ***msg.payload*** is an array containing two objects, the first object will be written as the set of named fields and the second is the set of named tags.
+
+For example, the following simple flow injects three fields along with two tags, `tag1` and `tag2`:
+
+    [{"id":"f35e5815.9ac48","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":180,"wires":[["cc6a2a67.5edc28"]]},{"id":"cc6a2a67.5edc28","type":"function","z":"c70ec85f.ffbc3","name":"Fields and Tags","func":"msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":340,"y":180,"wires":[["42816c54.99f794"]]},{"id":"42816c54.99f794","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":180,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+The function node consists of the following code:
+
+    msg.payload = [{
+        numValue: 12,
+        randomValue: Math.random() * 10,
+        strValue: "message2",
+        //time: new Date("2020-07-09T16:00:00Z")
+    },
+    {
+        tag1: "sensor1",
+        tag2: "device2"
+    }];
+    return msg;
+
+Finally, if ***msg.payload*** is an array of arrays, it will be written as a series of points containing fields and tags.
+
+For example, the following flow injects two points with timestamps specified.  
+
+    [{"id":"cab64da3.ec089","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":240,"wires":[["45dc1b5a.7ab1d4"]]},{"id":"45dc1b5a.7ab1d4","type":"function","z":"c70ec85f.ffbc3","name":"multiple readings","func":"msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":240,"wires":[["3c9f8227.c549de"]]},{"id":"3c9f8227.c549de","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":240,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
+
+The function node in the above flow looks as follows:
+
+    msg.payload = [
+        [{
+            numValue: 10,
+            randomValue: Math.random() * 10,
+            strValue: "message1",
+            time: new Date("2020-07-16T13:00:02Z")
+        },
+        {
+            tag1: "sensor1",
+            tag2: "device2"
+        }],
+        [{
+            numValue: 20,
+            randomValue: Math.random() * 10,
+            strValue: "message2",
+            time: new Date("2020-07-16T13:00:03Z")
+        },
+        {
+            tag1: "sensor2",
+            tag2: "device1"
+        }]
+        ];
+    return msg;
+
+Note how timestamps are specified - the number of milliseconds since 1 January 1970 00:00:00 UTC. In this case do not forget to set "ms" in "Time Precision" of the influx out node.
+
+### Catching Failed Reads and Writes
+
+Errors in reads and writes can be caught using the node-red `catch` node as usual. Standard error information is availlable in the default `msg.error` field; additional information about the underlying error is in the `msg.influx_error` field. Currently, this includes the HTTP status code returned from the influxdb server.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 In a first operation mode, selectable with a como box, these nodes use the <a href="https://www.npmjs.com/package/influx" target="_new">influxDB 1.x client</a> for node.js, specifically calling the **writePoints()**, and **query()** methods. Currently they can only communicate with one influxdb host. These nodes are used for writing and querying data in InfluxDB 1.x to 1.8+.
 
-Additionally, in a second operation mode, the nodes leverage the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new"> influxDB 2.0 API compatibility endpoints</a> available in the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for node.js. These nodes are used for writing and querying data with Flux in InfluxDB 1.8+.
+Additionally, in a second operation mode, the nodes leverage the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new"> influxDB 2.0 API compatibility endpoints</a> available in the <a href="https://github.com/influxdata/influxdb-client-js" target="_new">InfluxDB 2.0 client libraries</a> for node.js. These nodes are used for writing and querying data with Flux in InfluxDB 1.8+.
 
-A third operation mode, available as **InfluxDB 2** category, makes use of the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for writing and querying data with Flux in InfluxDB 2.0.
+A third operation mode, available as **InfluxDB 2** category, makes use of the <a href="https://github.com/influxdata/influxdb-client-js" target="_new">InfluxDB 2.0 client libraries</a> for writing and querying data with Flux in InfluxDB 2.0.
 
 Operation modes are selectable from the `Version` field in the configuration node. See the documentation of the different nodes to check the options provided by each of the modes.
 
 ## Prerequisites
 
-To run this you'll need access to an InfluxDB database version 1.x, 1.8+ or 2.0. See the <a href="https://influxdb.com/" target="_new">InfluxDB site</a> for more information. The last release of this node has been tested with InfluxDB 1.8+ and 2.0.
+To run this you'll need access to an InfluxDB database version 1.x, 1.8+ or 2.0. See the <a href="https://influxdb.com/" target="_new">InfluxDB site</a> for more information. The latest release of this node has been tested with InfluxDB 1.8+ and 2.0.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # node-red-contrib-influxdb
 
-<a href="http://nodered.org" target="_new">Node-RED</a> nodes to write and query data from an influxdb time series database. 
+<a href="http://nodered.org" target="_new">Node-RED</a> nodes to write and query data from an InfluxDB time series database. 
 
-A first set of nodes, available under the category **InfluxDB 18** in the NR editor, use the <a href="https://www.npmjs.com/package/influx" target="_new">influxDB 1.x client</a> for node.js, specifically calling the **writePoints()**, and **query()** methods. Currently these nodes can only communicate with one influxdb host. These nodes are used for writing and querying data in InfluxDB 1.x to 1.8+.
+In a first operation mode, selectable with a como box, these nodes use the <a href="https://www.npmjs.com/package/influx" target="_new">influxDB 1.x client</a> for node.js, specifically calling the **writePoints()**, and **query()** methods. Currently they can only communicate with one influxdb host. These nodes are used for writing and querying data in InfluxDB 1.x to 1.8+.
 
-A second set of nodes, available under the category **InfluxDB 18 flux** in the NR editor, use the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new"> influxDB 2.0 API compatibility endpoints</a> available in the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for node.js. These nodes are used for writing and querying data with Flux in InfluxDB 1.8+.
+Additionally, in a second operation mode, the nodes leverage the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new"> influxDB 2.0 API compatibility endpoints</a> available in the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for node.js. These nodes are used for writing and querying data with Flux in InfluxDB 1.8+.
 
-A third set of nodes, available as **InfluxDB 2** category, leverage the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for writing and querying data with Flux in InfluxDB 2.0.
+A third operation mode, available as **InfluxDB 2** category, makes use of the <a href="https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints" target="_new">InfluxDB 2.0 client libraries</a> for writing and querying data with Flux in InfluxDB 2.0.
+
+Operation modes are selectable from the `Version` field in the configuration node. See the documentation of the different nodes to check the options provided by each of the modes.
 
 ## Prerequisites
 
-To run this you'll need access to an InfluxDB database version 1.x, 1.8+ or 2.0. See the <a href="https://influxdb.com/" target="_new">influxdb site</a> for more information. The last release of this node has been tested with InfluxDB 1.8 and 2.0.
+To run this you'll need access to an InfluxDB database version 1.x, 1.8+ or 2.0. See the <a href="https://influxdb.com/" target="_new">InfluxDB site</a> for more information. The last release of this node has been tested with InfluxDB 1.8+ and 2.0.
 
 ## Install
 
@@ -19,9 +21,9 @@ Usually this is `~/.node-red` .
 
     npm install node-red-contrib-influxdb
 
-##  **Usage - InfluxDB 18**
+##  **Usage
 
-Nodes to write and query data from an influxdb time series database. Supoorted versions from 1.x to 1.8.
+Nodes to write and query data from an influxdb time series database. Supoorted versions from 1.x to 2.0.
 
 ### Input Node
 
@@ -177,225 +179,3 @@ this includes the HTTP status code returned from the influxdb server. The `influ
 node will always throw a `503`, whereas the write nodes will include other status codes
 as detailed in the 
 [Influx API documentation](https://docs.influxdata.com/influxdb/v1.8/tools/api/#status-codes-and-responses-2).
-
-## **Usage - InfluxDB 18 flux**
-
-Nodes to write and query data from an influxdb time series database using compatibility endpoints of the InfluxDB 2.0 client libraries for writing and querying data with Flux. Supoorted version is 1.8+.
-
-### Input Node
-
-Allows flux queries to be made to an influxdb time series database. The flux query can be specified in the configuration property or using the property **msg.query**. Setting it in the node will override the **msg.query**. The results will be returned in **msg.payload**.
-
-For example, here is a simple flow to query all of the points in the `test` database, where the query is in the configuration of the influxdb input node (copy and paste to your NR editor).
-
-    [{"id":"2c24bff8.5d5fb","type":"influxdb 1.8 flux in","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","query":"from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)","name":"","x":520,"y":300,"wires":[["9ec53e18.774c18"]]},{"id":"9ec53e18.774c18","type":"debug","z":"653805bf.2d2784","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":930,"y":300,"wires":[]},{"id":"a89497f8.4c509","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":140,"y":300,"wires":[["2c24bff8.5d5fb"]]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-This flow performs the same, but using a query in the msg.payload:
-
-    [{"id":"661fd96e.7691f8","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"topic":"","payload":"","payloadType":"date","x":160,"y":540,"wires":[["ce9462a5.eed9a8"]]},{"id":"ce9462a5.eed9a8","type":"function","z":"653805bf.2d2784","name":"simple query","func":"msg.query='from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)';\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":540,"wires":[["3d674774.6f9d08"]]},{"id":"f231bdfa.999e8","type":"debug","z":"653805bf.2d2784","name":"","active":true,"console":"false","complete":"false","x":810,"y":540,"wires":[]},{"id":"3d674774.6f9d08","type":"influxdb 1.8 flux in","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","query":"","name":"","x":580,"y":540,"wires":[["f231bdfa.999e8"]]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-The function node in this flow sets the `msg.query` property as follows:
-
-    msg.query='from(bucket: "test/autogen") |> range(start: -1m, stop: 1h)';
-    return msg;
-
-### Output Node
-
-Writes one or more points (fields and tags) to a measurement.
-
-The fields and tags to write are in ***msg.payload***. If the message is a string, number or boolean, it will be written as a single value to the specified measurement (field called *value*).
-
-For example, the following flow injects a single random field called `value` into the measurement `test` in the database `test` with the current timestamp.
-
-    [{"id":"120c5823.db609","type":"inject","z":"653805bf.2d2784","name":"","props":[{"p":"payload","v":"","vt":"date"},{"p":"topic","v":"","vt":"string"}],"repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":60,"wires":[["eb30f561.c70148"]]},{"id":"eb30f561.c70148","type":"function","z":"653805bf.2d2784","name":"Single Value","func":"msg.payload = Math.random() * 10;\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":330,"y":60,"wires":[["cad9f0d2.1463e8"]]},{"id":"cad9f0d2.1463e8","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":580,"y":60,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-The function node consists of the following:
-
-    msg.payload = Math.random() * 10;
-    return msg;
-
-If ***msg.payload*** is an object containing multiple properties, the fields will be written to the measurement.
-
-For example, the following flow injects four fields, `numValue`, `strValue`, `floatValue` and `booleanValue` into the same measurement with the current timestamp. A `time` field can be specified if the timestamp for the measurement is not the current one.
-
-    [{"id":"4fc65aec.2d88bc","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":120,"wires":[["b6d751d.392793"]]},{"id":"b6d751d.392793","type":"function","z":"653805bf.2d2784","name":"Fields","func":"msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":310,"y":120,"wires":[["207a1809.718b5"]]},{"id":"207a1809.718b5","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":580,"y":120,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-The function node in the flow above consists of the following:
-
-    msg.payload = {
-        numValue: 123.0,
-        strValue: "message",
-        floatValue: Math.random() * 10,
-        ooleanValue: true,
-        //time: new Date("2020-07-15T12:00:00Z")
-    }
-    return msg;
-
-If ***msg.payload*** is an array containing two objects, the first object will be written as the set of named fields and the second is the set of named tags.
-
-For example, the following simple flow injects three fields along with two tags, `tag1` and `tag2`:
-
-    [{"id":"e33df9a0.62473","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":180,"wires":[["d195b182.a4702"]]},{"id":"d195b182.a4702","type":"function","z":"653805bf.2d2784","name":"Fields and Tags","func":"msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":340,"y":180,"wires":[["bf4607a5.cc9a88"]]},{"id":"bf4607a5.cc9a88","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":610,"y":180,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-The function node consists of the following code:
-
-    msg.payload = [{
-        numValue: 12,
-        randomValue: Math.random() * 10,
-        strValue: "message2",
-        //time: new Date("2020-07-09T16:00:00Z")
-    },
-    {
-        tag1: "sensor1",
-        tag2: "device2"
-    }];
-    return msg;
-
-Finally, if ***msg.payload*** is an array of arrays, it will be written as a series of points containing fields and tags.
-
-For example, the following flow injects two points with timestamps specified.  
-
-    [{"id":"99251519.a7b3e8","type":"inject","z":"653805bf.2d2784","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":240,"wires":[["1bf3451b.36b1bb"]]},{"id":"1bf3451b.36b1bb","type":"function","z":"653805bf.2d2784","name":"multiple readings","func":"msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":240,"wires":[["fd4b0034.d7eb7"]]},{"id":"fd4b0034.d7eb7","type":"influxdb 1.8 flux out","z":"653805bf.2d2784","influxdb":"eb34baa.56944c8","database":"test","measurement":"test","precision":"ms","retentionPolicy":"","name":"","x":610,"y":240,"wires":[]},{"id":"eb34baa.56944c8","type":"influxdb18flux","z":"","url":"https://localhost:8086","name":""}]
-
-The function node in the above flow looks as follows:
-
-    msg.payload = [
-        [{
-            numValue: 10,
-            randomValue: Math.random() * 10,
-            strValue: "message1",
-            time: new Date("2020-07-16T13:00:02Z")
-        },
-        {
-            tag1: "sensor1",
-            tag2: "device2"
-        }],
-        [{
-            numValue: 20,
-            randomValue: Math.random() * 10,
-            strValue: "message2",
-            time: new Date("2020-07-16T13:00:03Z")
-        },
-        {
-            tag1: "sensor2",
-            tag2: "device1"
-        }]
-        ];
-    return msg;
-
-Note how timestamps are specified - the number of milliseconds since 1 January 1970 00:00:00 UTC. In this case do not forget to set "ms" in "Time Precision" of the influx out node.
-
-### Catching Failed Reads and Writes
-
-Errors in reads and writes can be caught using the node-red `catch` node as usual. Standard error information is availlable in the default `msg.error` field; additional information about the underlying error is in the `msg.influx_error` field. Currently, this includes the HTTP status code returned from the influxdb server.
-
-## **Usage - InfluxDB 2**
-
-Nodes to write and query data from an influxdb time series database using the InfluxDB 2.0 client libraries for writing and querying data with Flux. Supoorted version is 2.0.
-
-### Input Node
-
-Allows flux queries to be made to an influxdb time series database. The flux query can be specified in the configuration property or using the property **msg.query**. Setting it in the node will override the **msg.query**. The results will be returned in **msg.payload**.
-
-For example, here is a simple flow to query all of the points in the `test` bucket, where the query is in the configuration of the influxdb input node (copy and paste to your NR editor).
-
-    [{"id":"3e760db.d141d72","type":"debug","z":"c70ec85f.ffbc3","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":930,"y":300,"wires":[]},{"id":"6d054c00.b726dc","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":140,"y":300,"wires":[["de82c653.cd498"]]},{"id":"de82c653.cd498","type":"influxdb 2 in","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","query":"from(bucket: \"test\") |> range(start: -1m, stop: 1h)","name":"","x":500,"y":300,"wires":[["3e760db.d141d72"]]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-This flow performs the same, but using a query in the msg.payload:
-
-    [{"id":"e521a270.12701","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"topic":"","payload":"","payloadType":"date","x":160,"y":520,"wires":[["68210f4f.60f99"]]},{"id":"68210f4f.60f99","type":"function","z":"c70ec85f.ffbc3","name":"simple query","func":"msg.query='from(bucket: \"test\") |> range(start: -1m, stop: 1h)';\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":520,"wires":[["664bc03e.d3311"]]},{"id":"9a24c95c.a13a9","type":"debug","z":"c70ec85f.ffbc3","name":"","active":true,"console":"false","complete":"false","x":810,"y":520,"wires":[]},{"id":"664bc03e.d3311","type":"influxdb 2 in","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","query":"","name":"","x":580,"y":520,"wires":[["9a24c95c.a13a9"]]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-The function node in this flow sets the `msg.query` property as follows:
-
-    msg.query='from(bucket: "test") |> range(start: -1m, stop: 1h)';
-    return msg;
-
-### Output Node
-
-Writes one or more points (fields and tags) to a measurement.
-
-The fields and tags to write are in ***msg.payload***. If the message is a string, number or boolean, it will be written as a single value to the specified measurement (field called *value*).
-
-For example, the following flow injects a single random field called `value` into the measurement `test` in the bucket `test` and organisation `my-org` with the current timestamp.
-
-    [{"id":"d9f0ebfc.ecfec8","type":"inject","z":"c70ec85f.ffbc3","name":"","props":[{"p":"payload","v":"","vt":"date"},{"p":"topic","v":"","vt":"string"}],"repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":60,"wires":[["c555c3a0.204c58"]]},{"id":"c555c3a0.204c58","type":"function","z":"c70ec85f.ffbc3","name":"Single Value","func":"msg.payload = Math.random() * 10;\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":330,"y":60,"wires":[["f5a4befd.56d75"]]},{"id":"f5a4befd.56d75","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":60,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-The function node consists of the following:
-
-    msg.payload = Math.random() * 10;
-    return msg;
-
-If ***msg.payload*** is an object containing multiple properties, the fields will be written to the measurement.
-
-For example, the following flow injects four fields, `numValue`, `strValue`, `floatValue` and `booleanValue` into the same measurement with the current timestamp. A `time` field can be specified if the timestamp for the measurement is not the current one.
-
-    [{"id":"1606c311.639f3d","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":120,"wires":[["6fad44a5.d5f544"]]},{"id":"6fad44a5.d5f544","type":"function","z":"c70ec85f.ffbc3","name":"Fields","func":"msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":310,"y":120,"wires":[["a57b64be.670488"]]},{"id":"a57b64be.670488","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":120,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-The function node in the flow above consists of the following:
-
-    msg.payload = {
-        numValue: 123.0,
-        strValue: "message",
-        floatValue: Math.random() * 10,
-        ooleanValue: true,
-        //time: new Date("2020-07-15T12:00:00Z")
-    }
-    return msg;
-
-If ***msg.payload*** is an array containing two objects, the first object will be written as the set of named fields and the second is the set of named tags.
-
-For example, the following simple flow injects three fields along with two tags, `tag1` and `tag2`:
-
-    [{"id":"f35e5815.9ac48","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":180,"wires":[["cc6a2a67.5edc28"]]},{"id":"cc6a2a67.5edc28","type":"function","z":"c70ec85f.ffbc3","name":"Fields and Tags","func":"msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":340,"y":180,"wires":[["42816c54.99f794"]]},{"id":"42816c54.99f794","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":180,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-The function node consists of the following code:
-
-    msg.payload = [{
-        numValue: 12,
-        randomValue: Math.random() * 10,
-        strValue: "message2",
-        //time: new Date("2020-07-09T16:00:00Z")
-    },
-    {
-        tag1: "sensor1",
-        tag2: "device2"
-    }];
-    return msg;
-
-Finally, if ***msg.payload*** is an array of arrays, it will be written as a series of points containing fields and tags.
-
-For example, the following flow injects two points with timestamps specified.  
-
-    [{"id":"cab64da3.ec089","type":"inject","z":"c70ec85f.ffbc3","name":"","repeat":"","crontab":"","once":false,"onceDelay":"","topic":"","payload":"","payloadType":"date","x":140,"y":240,"wires":[["45dc1b5a.7ab1d4"]]},{"id":"45dc1b5a.7ab1d4","type":"function","z":"c70ec85f.ffbc3","name":"multiple readings","func":"msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","x":350,"y":240,"wires":[["3c9f8227.c549de"]]},{"id":"3c9f8227.c549de","type":"influxdb 2 out","z":"c70ec85f.ffbc3","influxdb":"3dcd3c8e.fe9b24","org":"my-org","bucket":"test","measurement":"test","precision":"ms","name":"","x":650,"y":240,"wires":[]},{"id":"3dcd3c8e.fe9b24","type":"influxdb2","z":"","url":"https://localhost:9999","token":"M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==","name":""}]
-
-The function node in the above flow looks as follows:
-
-    msg.payload = [
-        [{
-            numValue: 10,
-            randomValue: Math.random() * 10,
-            strValue: "message1",
-            time: new Date("2020-07-16T13:00:02Z")
-        },
-        {
-            tag1: "sensor1",
-            tag2: "device2"
-        }],
-        [{
-            numValue: 20,
-            randomValue: Math.random() * 10,
-            strValue: "message2",
-            time: new Date("2020-07-16T13:00:03Z")
-        },
-        {
-            tag1: "sensor2",
-            tag2: "device1"
-        }]
-        ];
-    return msg;
-
-Note how timestamps are specified - the number of milliseconds since 1 January 1970 00:00:00 UTC. In this case do not forget to set "ms" in "Time Precision" of the influx out node.
-
-### Catching Failed Reads and Writes
-
-Errors in reads and writes can be caught using the node-red `catch` node as usual. Standard error information is availlable in the default `msg.error` field; additional information about the underlying error is in the `msg.influx_error` field. Currently, this includes the HTTP status code returned from the influxdb server.

--- a/influxdb.html
+++ b/influxdb.html
@@ -1,23 +1,39 @@
-<script type="text/x-red" data-template-name="influxdb">
+<script type="text/x-red" data-template-name="influxdb">    
     <div class="form-row">
+        <label for="node-config-input-influxdbVersion"><i class="fa fa-code-fork"></i> <span data-i18n="influxdb.label.version"></span></label>
+        <select type="text" id="node-config-input-influxdbVersion">
+            <option value="1.8">1.8</option> 
+            <option value="1.8 flux">1.8 flux</option> 
+            <option value="2.0">2.0</option> 
+        </select>
+    </div>
+    <div class="form-row" id="node-config-row-hostname-port">
         <label for="node-config-input-hostname"><i class="fa fa-server"></i> <span data-i18n="influxdb.label.host"></span></label>
         <input class="input-append-left" type="text" id="node-config-input-hostname" placeholder="localhost" style="width: 40%;" >
         <label for="node-config-input-port" style="margin-left: 10px; width: 35px; "> <span data-i18n="influxdb.label.port"></span></label>
         <input type="text" id="node-config-input-port" style="width:45px">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-config-row-url">
+        <label for="node-config-input-url"><i class="fa fa-server"></i> <span data-i18n="influxdb.label.url"></span></label>
+        <input class="input-append-left" type="text" id="node-config-input-url" placeholder="http://localhost:8086">
+    </div>
+    <div class="form-row" id="node-config-row-database">
         <label for="node-config-input-database"><i class="fa fa-database"></i> <span data-i18n="influxdb.label.database"></span></label>
         <input type="text" id="node-config-input-database">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-config-row-username">
         <label for="node-config-input-username"><i class="fa fa-user"></i> <span data-i18n="node-red:common.label.username"></span></label>
         <input type="text" id="node-config-input-username">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-config-row-password">
         <label for="node-config-input-password"><i class="fa fa-lock"></i> <span data-i18n="node-red:common.label.password"></span></label>
         <input type="password" id="node-config-input-password">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-config-row-token">
+        <label for="node-config-input-token"><i class="fa fa-lock"></i> <span data-i18n="influxdb.label.token"></span></label>
+        <input type="password" id="node-config-input-token">
+    </div>    
+    <div class="form-row" id="node-config-row-enableSecureConnection">
         <input type="checkbox" id="node-config-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-config-input-usetls" style="width: auto" data-i18n="influxdb.label.use-tls"></label>
         <div id="node-config-row-tls" class="hide">
@@ -37,25 +53,40 @@
         color: "rgb(218, 196, 180)",
         defaults: {
             hostname: {value: "127.0.0.1", required: true},
-            port: {value: 8086, required: true},
+            port: {value: 8086, required: true},            
 			protocol: {value: "http", required: true},
-            database: {value: "", required: true},
+            database: {value: "database", required: true},
             name: {value: ""},
             usetls: {value: false},
-            tls: {type:"tls-config",required: false}
+            tls: {type:"tls-config",required: false},
+            influxdbVersion: {value: "1.8", required: true},
+            url: {value: "http://localhost:8086", required: true}
         },
         credentials: {
             username: {type: "text"},
-            password: {type: "password"}
+            password: { type: "password" },
+            token: {type: "password"}
         },
-        label: function() {
-            return this.name || this.hostname + ":" + this.port + "/" + this.database;
+        label: function () {
+            if (this.influxdbVersion === '1.8') {
+                return this.name || "[v1.8] - " + this.hostname + ":" + this.port + "/" + this.database;
+            } else if (this.influxdbVersion === '1.8 flux') {
+                return this.name || "[v1.8 flux] - " + this.url;
+            } else if (this.influxdbVersion === '2.0') {
+                return this.name || "[v2.0] - " + this.url;
+            }         
         },
-        oneditprepare: function() {
+        oneditprepare: function () {
+                
+            //console.log($("#node-config-input-influxdbVersion option:selected").text());
+            //console.log($("#node-config-input-influxdbVersion option:selected").val());
+
+            /*
             if (typeof this.usetls === 'undefined') {
                 this.usetls = false;
-                $("#node-config-input-usetls").prop("checked",false);
+                $("#node-config-input-usetls").prop("checked", false);
             }
+            */
             function updateTLSOptions() {
                 if ($("#node-config-input-usetls").is(':checked')) {
                     $("#node-config-row-tls").show();
@@ -63,9 +94,54 @@
                     $("#node-config-row-tls").hide();
                 }
             }
-            updateTLSOptions();
-            $("#node-config-input-usetls").on("click",function() {
-                updateTLSOptions();
+
+            function update18Options() {                
+                $("#node-config-row-hostname-port").show();
+                $("#node-config-row-url").hide();
+                $("#node-config-row-database").show();
+                $("#node-config-row-username").show();
+                $("#node-config-row-password").show();
+                $("#node-config-row-token").hide();
+                $("#node-config-row-enableSecureConnection").show();                
+            }
+
+            function update18FluxOptions() {                
+                $("#node-config-row-hostname-port").hide();
+                $("#node-config-row-url").show();
+                $("#node-config-row-database").hide();
+                $("#node-config-row-username").show();
+                $("#node-config-row-password").show();
+                $("#node-config-row-token").hide();
+                $("#node-config-row-enableSecureConnection").hide();   
+            }
+
+            function update20Options() {                
+                $("#node-config-row-hostname-port").hide();
+                $("#node-config-row-url").show();
+                $("#node-config-row-database").hide();
+                $("#node-config-row-username").hide();
+                $("#node-config-row-password").hide();
+                $("#node-config-row-token").show();
+                $("#node-config-row-enableSecureConnection").hide();  
+            }
+
+            $("#node-config-input-influxdbVersion").change(function () {
+                if ($("#node-config-input-influxdbVersion option:selected").val() === '1.8') {
+                    //alert("Handler for .change() 1.8 called.");
+                    update18Options();
+                    updateTLSOptions();
+                    $("#node-config-input-usetls").on("click", function () {
+                        updateTLSOptions();
+                    });
+                }
+                if ($("#node-config-input-influxdbVersion option:selected").val() === '1.8 flux') {
+                    //alert("Handler for .change() 1.8 flux called.");
+                    update18FluxOptions();
+                }
+                if ($("#node-config-input-influxdbVersion option:selected").val() === '2.0') {
+                    //alert("Handler for .change() 2.0 flux called.");
+                    update20Options();
+                }          
             });
         }
     });
@@ -76,11 +152,23 @@
         <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb.label.server"></span></label>
         <input type="text" id="node-input-influxdb">
     </div>
+    <div class="form-row" id="node-input-row-org">
+        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb.label.org"></span></label>
+        <input type="text" id="node-input-org">
+    </div>
+    <div class="form-row" id="node-input-row-bucket">
+        <label for="node-input-bucket"><i class="fa fa-database"></i> <span data-i18n="influxdb.label.bucket"></span></label>
+        <input type="text" id="node-input-bucket">
+    </div>
+    <div class="form-row" id="node-input-row-database">
+        <label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="influxdb.label.database"></span></label>
+        <input type="text" id="node-input-database">
+    </div>
     <div class="form-row">
         <label for="node-input-measurement"><i style="width: 10px;" class="fa fa-rss"></i> <span data-i18n="influxdb.label.measurement"></span></label>
         <input type="text" id="node-input-measurement">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-input-row-enableAdvancedOptions">
         <input type="checkbox" id="advanced-options-checkbox" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="advanced-options-checkbox" style="width: 70%;"><span data-i18n="influxdb.label.use-advanced-query"></span></label>
         <div id="advanced-options-div" class="hide" style="margin-left: 20px; margin-top: 10px;">
@@ -103,17 +191,32 @@
                 <input type="text" style="width:55%" id="node-input-retentionPolicy">
             </div>
         </div>  
-    </div>  
+    </div>
+    <div class="form-row" id="node-input-row-precisionV18FluxV20">
+        <label for="node-input-precisionV18FluxV20"><i class="fa fa-clock-o"></i> <span data-i18n="influxdb.label.time-precision"></span></label>
+        <select type="text" id="node-input-precisionV18FluxV20">
+            <option value="ns">Nanoseconds (ns)</option> 
+            <option value="us">Microseconds (us)</option> 
+            <option value="ms">Milliseconds (ms)</option> 
+            <option value="s">Seconds (s)</option>
+        </select>  
+    </div>
+    <div class="form-row" id="node-input-row-retentionPolicyV18Flux">
+        <label for="node-input-retentionPolicyV18Flux"><i class="fa fa-gavel"></i> <span data-i18n="influxdb.label.retention-policy"></span></label>
+        <input type="text" id="node-input-retentionPolicyV18Flux">
+    </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
-    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb.tip"></span></div>
+    <div class="form-tips" id="node-warning-measurement"><span data-i18n="[html]influxdb.tip.measurement"></span></div>
+    <div class="form-tips" id="node-warning-retention-policy"><span data-i18n="[html]influxdb.tip.retention-policy"></span></div>
 </script>
 
 <script type="text/x-red" data-help-name="influxdb out">
+    <p><b>InfluxDB 1.8</b></p>
     <p>A simple influxdb output node to write values and tags to an influxdb measurement.</p>
-    <p>The fields and tags to write are in <b>msg.payload</b>.  If <b>msg.payload</b> is a string, number, or boolean, 
+    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
     it will be written as a single value to the specified measurement (called <i>value</i>).</p>
     <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
     <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
@@ -123,19 +226,36 @@
     measurement name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
     <p>Check <i>Advanced Query Options</i> to specify a time precision and retention policy for the insertion.<p>
     <p>The advanced query options <i>Time Precision</i> and <i>Retention Policy</i> can be overwritten using 
-    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p> 
+    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p>
+
+    <p>&nbsp;</p><p><b>InfluxDB 1.8 Flux and InfluxDB 2.0</b></p>
+    <p>A simple output node to write values and tags to an influxdb measurement.</p>
+    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
+    it will be written as a single value to the specified measurement (called <i>value</i>).</p>
+    <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
+    <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
+    the second is the set of named tags.</p>
+    <p>Finally, if <b>msg.payload</b> is an array of arrays, it will be written as a series of points containing fields and tags.</p>
+    <p>If the <i>measurement</i> field is not set in the node configuration, the user can send in data with a specified measurement 
+    name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
+    <p>If no retention policy is specified, <i>autogen</i> will be assumed.</p>
 </script>
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb out', {
-        category: 'InfluxDB 18',
+        category: 'storage-output',
         color: "rgb(218, 196, 180)",
         defaults: {
             influxdb: {type: "influxdb", required: true},
             name: {value: ""},
             measurement: {value: ""},
             precision: {value: ""},
-            retentionPolicy: {value: ""}
+            retentionPolicy: {value: ""},
+            database: {value: "database", required: true},
+            precisionV18FluxV20: {value: "ms"},
+            retentionPolicyV18Flux: {value: ""},
+            org: {value: "organisation", required: true},
+            bucket: {value: "bucket", required: true}
         },
         inputs: 1,
         outputs: 0,
@@ -149,14 +269,6 @@
             return this.name ? "node_label_italic" : "";
         },
         oneditprepare: function() {
-            $("#node-input-measurement").change(function () {
-                if($("#node-input-measurement").val() === "") {
-                    $("#node-warning").show();
-                } else {
-                    $("#node-warning").hide();
-                }
-            });
-
             $("#advanced-options-checkbox").change( function () {
                 if ($('#advanced-options-checkbox').is(":checked")) {
                     $("#advanced-options-div").show();
@@ -173,6 +285,69 @@
                 $('#advanced-options-checkbox').prop('checked', true);
                 $("#advanced-options-div").show();
             }
+
+            function update18Options() {                
+                //console.log('update 18 options called!');
+                $("#node-input-row-org").hide();
+                $("#node-input-row-bucket").hide();
+                $("#node-input-row-database").hide();
+                $("#node-input-row-enableAdvancedOptions").show();
+                $("#node-input-row-precisionV18FluxV20").hide();
+                $("#node-input-row-retentionPolicyV18Flux").hide();
+                $("#node-warning-retention-policy").show();
+            }
+
+            function update18FluxOptions() {       
+                //console.log('update 18 Flux options called!');
+                $("#node-input-row-org").hide();
+                $("#node-input-row-bucket").hide();         
+                $("#node-input-row-database").show();
+                $("#node-input-row-enableAdvancedOptions").hide();
+                $("#node-input-row-precisionV18FluxV20").show();
+                $("#node-input-row-retentionPolicyV18Flux").show();
+                $("#node-warning-retention-policy").show();
+            }
+
+            function update20Options() {
+                //console.log('update 20 options called!');
+                $("#node-input-row-org").show();
+                $("#node-input-row-bucket").show();           
+                $("#node-input-row-database").hide();
+                $("#node-input-row-enableAdvancedOptions").hide();
+                $("#node-input-row-precisionV18FluxV20").show();
+                $("#node-input-row-retentionPolicyV18Flux").hide();
+                $("#node-warning-retention-policy").hide();
+            }
+
+            $("#node-input-influxdb").change(function () {
+                var optionSelected = $("#node-input-influxdb option:selected").text();
+                var influxDBVersionMatches = optionSelected.match(/\[(.*?)\]/);
+                var influxDBVersion = '';
+                if (influxDBVersionMatches) {
+                    var influxDBVersion = influxDBVersionMatches[1];
+                }
+                
+                //console.log(influxDBVersion);
+                
+                if (influxDBVersion === 'v1.8' || influxDBVersion == '') {
+                    //alert("Handler for .change() 1.8 called.");
+                    update18Options();
+                } else if (influxDBVersion === 'v1.8 flux') {
+                    //alert("Handler for .change() 1.8 flux called.");
+                    update18FluxOptions();                    
+                } else if (influxDBVersion === 'v2.0') {
+                    //alert("Handler for .change() 2.0 called.");
+                    update20Options();                    
+                }
+            });
+
+            $("#node-input-measurement").change(function () {
+                if($("#node-input-measurement").val() === "") {
+                    $("#node-warning-measurement").show();
+                } else {
+                    $("#node-warning-measurement").hide();
+                }
+            });
         },
         oneditsave: function() {
             // reset inputs if we are not using advanced options
@@ -217,23 +392,23 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
-    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb.tip"></span></div>
 </script>
 
 <script type="text/x-red" data-help-name="influxdb batch">
+    <p><b>InfluxDB 1.8</b></p>
     <p>A influxdb output node to write multiple points (fields and tags) to multiple influxdb measurements.</p>
     <p>The <b>msg.payload</b> needs to be an array of <i>point</i> objects.</p>
-    <p>The <b>measurement</b> property of a point contains the name of the measurement for the point.  The <b>fields</b> property will contain the
-    fields of the point.  If supplied, the <b>tags</b> property will contain the tags for the point.  To set the time
+    <p>The <b>measurement</b> property of a point contains the name of the measurement for the point. The <b>fields</b> property will contain the
+    fields of the point.  If supplied, the <b>tags</b> property will contain the tags for the point. To set the time
     for the point, supply a <b>timestamp</b> property.</p>
     <p>Check <i>Advanced Query Options</i> to specify a time precision and retention policy for the insertion.<p>
     <p>The advanced query options <i>Time Precision</i> and <i>Retention Policy</i> can be overwritten using 
-    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p>  
+    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p>
 </script>
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb batch', {
-        category: 'InfluxDB 18',
+        category: 'storage-output',
         color: "rgb(218, 196, 180)",
         paletteLabel: 'influx batch',
         defaults: {
@@ -286,15 +461,19 @@
         <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb.label.server"></span></label>
         <input type="text" id="node-input-influxdb">
     </div>
+    <div class="form-row" id="node-input-row-org">
+        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb.label.org"></span></label>
+        <input type="text" id="node-input-org">
+    </div>
     <div class="form-row">
         <label for="node-input-query"><i class="fa fa-briefcase"></i> <span data-i18n="influxdb.label.query"></span></label>
         <input type="text" id="node-input-query">
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-input-row-rawOutput">
         <input type="checkbox" id="node-input-rawOutput" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-rawOutput"><span data-i18n="influxdb.label.use-raw-output"></span></label>        
     </div>
-    <div class="form-row">
+    <div class="form-row" id="node-input-row-enableAdvancedOptions">
         <input type="checkbox" id="advanced-options-checkbox" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="advanced-options-checkbox" style="width: 70%;"><span data-i18n="influxdb.label.use-advanced-query"></span></label>
         <div id="advanced-options-div" class="hide" style="margin-left: 20px; margin-top: 10px;">
@@ -323,24 +502,30 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
-    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb.querytip"></span></div>
+    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb.tip.querytip"></span></div>
 </script>
 
 <script type="text/x-red" data-help-name="influxdb in">
+    <p><b>InfluxDB 1.8</b></p>
     <p>Allows basic queries to be made to an influxdb time series database.</p>
     <p>The query can be specified in the configuration property or using the property
-    <b>msg.query</b>.  The results will be returned in <b>msg.payload</b>.</p>
+    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
     <p>To output the results of the query in the raw output format returned by InfluxDb,
     check the <i>Raw Output</i> checkbox.</p>
     <p>Check <i>Advanced Query Options</i> to specify a time precision and retention policy for the query.<p>
-    <p>The raw output configuration can be overwritten by the message property <b>msg.rawOutput</b>. </p>
+    <p>The raw output configuration can be overwritten by the message property <b>msg.rawOutput</b>.</p>
     <p>The advanced query options <i>Time Precision</i> and <i>Retention Policy</i> can be overwritten using 
-    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p>  
+    message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p>
+
+    <p>&nbsp;</p><p><b>InfluxDB 1.8 Flux and InfluxDB 2.0</b></p>
+    <p>Allows basic queries to be made to an influxdb 2 time series database.</p>
+    <p>The flux query can be specified in the configuration property or using the property
+    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
 </script>
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb in', {
-        category: 'InfluxDB 18',
+        category: 'storage-output',
         color: "rgb(218, 196, 180)",
         defaults: {
             influxdb: {type: "influxdb", required: true},
@@ -348,7 +533,8 @@
             query: {value: ""},
             rawOutput: {value: false},
             precision: {value: ""},
-            retentionPolicy: {value: ""}
+            retentionPolicy: {value: ""},
+            org: {value: "organisation", required: true}
         },
         inputs: 1,
         outputs: 1,
@@ -385,6 +571,49 @@
                 $('#advanced-options-checkbox').prop('checked', true);
                 $("#advanced-options-div").show();
             }
+
+            function update18Options() {                
+                //console.log('update 18 options called!');                
+                $("#node-input-row-org").hide();
+                $("#node-input-row-rawOutput").show();
+                $("#node-input-row-enableAdvancedOptions").show();
+            }
+
+            function update18FluxOptions() {       
+                //console.log('update 18 Flux options called!');
+                $("#node-input-row-org").hide();
+                $("#node-input-row-rawOutput").hide();
+                $("#node-input-row-enableAdvancedOptions").hide();
+            }
+
+            function update20Options() {
+                //console.log('update 20 options called!');
+                $("#node-input-row-org").show();
+                $("#node-input-row-rawOutput").hide();
+                $("#node-input-row-enableAdvancedOptions").hide();
+            }
+
+            $("#node-input-influxdb").change(function () {
+                var optionSelected = $("#node-input-influxdb option:selected").text();
+                var influxDBVersionMatches = optionSelected.match(/\[(.*?)\]/);
+                var influxDBVersion = '';
+                if (influxDBVersionMatches) {
+                    var influxDBVersion = influxDBVersionMatches[1];
+                }
+                
+                //console.log(influxDBVersion);
+                
+                if (influxDBVersion === 'v1.8' || influxDBVersion == '') {
+                    //alert("Handler for .change() 1.8 called.");
+                    update18Options();
+                } else if (influxDBVersion === 'v1.8 flux') {
+                    //alert("Handler for .change() 1.8 flux called.");
+                    update18FluxOptions();                    
+                } else if (influxDBVersion === 'v2.0') {
+                    //alert("Handler for .change() 2.0 called.");
+                    update20Options();                    
+                }
+            });
         },
         oneditsave: function() {
             // reset inputs if we are not using advanced options
@@ -392,338 +621,6 @@
                 $("#node-input-precision").val("");
                 $("#node-input-retentionPolicy").val("");
             }
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb18flux">
-    <div class="form-row">
-        <label for="node-config-input-url"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.url"></span></label>
-        <input class="input-append-left" type="text" id="node-config-input-url" placeholder="http://localhost:8086">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-username"><i class="fa fa-user"></i> <span data-i18n="node-red:common.label.username"></span></label>
-        <input type="text" id="node-config-input-username">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-password"><i class="fa fa-lock"></i> <span data-i18n="node-red:common.label.password"></span></label>
-        <input type="password" id="node-config-input-password">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>    
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb18flux', {
-        category: 'config',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            url: {value: "http://localhost:8086", required: true},            
-            name: {value: ""}
-        },
-        credentials: {
-            username: {type: "text", required: true},
-            password: {type: "password", required: true}
-        },
-        label: function() {
-            return this.name || this.url;
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb 1.8 flux out">
-    <div class="form-row">
-        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.server"></span></label>
-        <input type="text" id="node-input-influxdb">
-    </div>
-    <div class="form-row">
-        <label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="influxdb18.label.database"></span></label>
-        <input type="text" id="node-input-database">
-    </div>
-    <div class="form-row">
-        <label for="node-input-measurement"><i style="width: 10px;" class="fa fa-rss"></i> <span data-i18n="influxdb18.label.measurement"></span></label>
-        <input type="text" id="node-input-measurement">
-    </div>
-    <div class="form-row">
-        <label for="node-input-precision"><i class="fa fa-clock-o"></i> <span data-i18n="influxdb18.label.time-precision"></span></label>
-        <select type="text" id="node-input-precision">
-            <option value="ns">Nanoseconds (ns)</option> 
-            <option value="us">Microseconds (us)</option> 
-            <option value="ms">Milliseconds (ms)</option> 
-            <option value="s">Seconds (s)</option>
-        </select>  
-    </div>
-    <div class="form-row">
-        <label for="node-input-retentionPolicy"><i class="fa fa-gavel"></i> <span data-i18n="influxdb18.label.retention-policy"></span></label>
-        <input type="text" id="node-input-retentionPolicy">
-    </div>
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-    <div class="form-tips" id="node-warning-measurement"><span data-i18n="[html]influxdb18.tip.measurement"></span></div>
-    <div class="form-tips" id="node-warning-retention-policy"><span data-i18n="[html]influxdb18.tip.retention-policy"></span></div>
-</script>
-
-<script type="text/x-red" data-help-name="influxdb 1.8 flux out">
-    <p>A simple influxdb 1.8 output node to write values and tags to an influxdb measurement.</p>
-    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
-    it will be written as a single value to the specified measurement (called <i>value</i>).</p>
-    <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
-    <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
-    the second is the set of named tags.</p>
-    <p>Finally, if <b>msg.payload</b> is an array of arrays, it will be written as a series of points containing fields and tags.</p>
-    <p>If the <i>measurement</i> field is not set in the node configuration, the user can send in data with a specified 
-    measurement name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
-    <p>The options <i>Precision</i> and <i>Retention</i> for time precision and retention policy can be overwritten 
-    using message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p> 
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb 1.8 flux out', {
-        category: 'InfluxDB 18 flux',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            influxdb: {type: "influxdb18flux", required: true},
-            database: {value: "", required: true},            
-            measurement: {value: ""},
-            precision: {value: "ms"},
-            retentionPolicy: {value: ""},
-            name: {value: ""}
-        },
-        inputs: 1,
-        outputs: 0,
-        icon: "influxdb.png",
-        align: "right",
-        label: function() {
-            var influxNode = RED.nodes.node(this.influxdb);
-            return this.name || (influxNode ? influxNode.label() + "/" + this.database + " " + this.measurement : "influxdb 1.8 flux out");
-        },
-        labelStyle: function() {
-            return this.name ? "node_label_italic" : "";
-        },
-        oneditprepare: function() {
-            $("#node-input-measurement").change(function () {
-                if($("#node-input-measurement").val() === "") {
-                    $("#node-warning-measurement").show();
-                } else {
-                    $("#node-warning-measurement").hide();
-                }
-            });
-            $("#node-input-retentionPolicy").change(function () {
-                if($("#node-input-retentionPolicy").val() === "") {
-                    $("#node-warning-retention-policy").show();
-                } else {
-                    $("#node-warning-retention-policy").hide();
-                }
-            });
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb 1.8 flux in">
-    <div class="form-row">
-        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.server"></span></label>
-        <input type="text" id="node-input-influxdb">
-    </div>
-    <div class="form-row">
-        <label for="node-input-query"><i class="fa fa-briefcase"></i> <span data-i18n="influxdb18.label.query"></span></label>
-        <input type="text" id="node-input-query">
-    </div> 
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb18.tip.querytip"></span></div>
-</script>
-
-<script type="text/x-red" data-help-name="influxdb 1.8 flux in">
-    <p>Allows basic queries to be made to an influxdb 1.8 flux time series database.</p>
-    <p>The flux query can be specified in the configuration property or using the property
-    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb 1.8 flux in', {
-        category: 'InfluxDB 18 flux',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            influxdb: {type: "influxdb18flux", required: true},
-            query: {value: ""},
-            name: {value: ""}
-        },
-        inputs: 1,
-        outputs: 1,
-        icon: "influxdb.png",
-        label: function() {
-            var influxNode = RED.nodes.node(this.influxdb);
-            return this.name || (influxNode ? influxNode.label() + " " + this.query : "influxdb 1.8 flux in");
-        },
-        labelStyle: function() {
-            return this.name ? "node_label_italic" : "";
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb2">
-    <div class="form-row">
-        <label for="node-config-input-url"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.url"></span></label>
-        <input class="input-append-left" type="text" id="node-config-input-url" placeholder="http://localhost:9999">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-token"><i class="fa fa-lock"></i> <span data-i18n="influxdb2.label.token"></span></label>
-        <input type="password" id="node-config-input-token">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>    
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb2', {
-        category: 'config',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            url: {value: "http://localhost:9999", required: true},            
-            token: {value: "", required: true},
-            name: {value: ""}
-        },
-        label: function() {
-            return this.name || this.url;
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb 2 out">
-    <div class="form-row">
-        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.server"></span></label>
-        <input type="text" id="node-input-influxdb">
-    </div>
-    <div class="form-row">
-        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb2.label.org"></span></label>
-        <input type="text" id="node-input-org">
-    </div>
-    <div class="form-row">
-        <label for="node-input-bucket"><i class="fa fa-database"></i> <span data-i18n="influxdb2.label.bucket"></span></label>
-        <input type="text" id="node-input-bucket">
-    </div>
-    <div class="form-row">
-        <label for="node-input-measurement"><i style="width: 10px;" class="fa fa-rss"></i> <span data-i18n="influxdb2.label.measurement"></span></label>
-        <input type="text" id="node-input-measurement">
-    </div>
-    <div class="form-row">
-        <label for="node-input-precision"><i class="fa fa-clock-o"></i> <span data-i18n="influxdb2.label.time-precision"></span></label>
-        <select type="text" id="node-input-precision">
-            <option value="ns">Nanoseconds (ns)</option> 
-            <option value="us">Microseconds (us)</option> 
-            <option value="ms">Milliseconds (ms)</option> 
-            <option value="s">Seconds (s)</option>
-        </select>  
-    </div>
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-    <div class="form-tips" id="node-warning-measurement"><span data-i18n="[html]influxdb2.tip.measurement"></span></div>    
-</script>
-
-<script type="text/x-red" data-help-name="influxdb 2 out">
-    <p>A simple influxdb 2 output node to write values and tags to an influxdb measurement.</p>
-    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
-    it will be written as a single value to the specified measurement (called <i>value</i>).</p>
-    <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
-    <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
-    the second is the set of named tags.</p>
-    <p>Finally, if <b>msg.payload</b> is an array of arrays, it will be written as a series of points containing fields and tags.</p>
-    <p>If the <i>measurement</i> field is not set in the node configuration, the user can send in data with a specified 
-    measurement name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
-    <p>The options <i>Precision</i> and <i>Retention</i> for time precision and retention policy can be overwritten 
-    using message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p> 
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb 2 out', {
-        category: 'InfluxDB 2',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            influxdb: {type: "influxdb2", required: true},
-            org: {value: "", required: true},
-            bucket: {value: "", required: true},  
-            measurement: {value: ""},
-            precision: {value: "ms"},
-            name: {value: ""}
-        },
-        inputs: 1,
-        outputs: 0,
-        icon: "influxdb.png",
-        align: "right",
-        label: function() {
-            var influxNode = RED.nodes.node(this.influxdb);
-            return this.name || (influxNode ? influxNode.label() + "/" + this.bucket + " " + this.measurement : "influxdb 2 out");
-        },
-        labelStyle: function() {
-            return this.name ? "node_label_italic" : "";
-        },
-        oneditprepare: function() {
-            $("#node-input-measurement").change(function () {
-                if($("#node-input-measurement").val() === "") {
-                    $("#node-warning-measurement").show();
-                } else {
-                    $("#node-warning-measurement").hide();
-                }
-            });
-        }
-    });
-</script>
-
-<script type="text/x-red" data-template-name="influxdb 2 in">
-    <div class="form-row">
-        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.server"></span></label>
-        <input type="text" id="node-input-influxdb">
-    </div>
-    <div class="form-row">
-        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb2.label.org"></span></label>
-        <input type="text" id="node-input-org">
-    </div>
-    <div class="form-row">
-        <label for="node-input-query"><i class="fa fa-briefcase"></i> <span data-i18n="influxdb2.label.query"></span></label>
-        <input type="text" id="node-input-query">
-    </div> 
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb2.tip.querytip"></span></div>
-</script>
-
-<script type="text/x-red" data-help-name="influxdb 2 in">
-    <p>Allows basic queries to be made to an influxdb 2 time series database.</p>
-    <p>The flux query can be specified in the configuration property or using the property
-    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
-</script>
-
-<script type="text/javascript">
-    RED.nodes.registerType('influxdb 2 in', {
-        category: 'InfluxDB 2',
-        color: "rgb(218, 196, 180)",
-        defaults: {
-            influxdb: {type: "influxdb2", required: true},
-            org: {value: "", required: true},
-            query: {value: ""},
-            name: {value: ""}
-        },
-        inputs: 1,
-        outputs: 1,
-        icon: "influxdb.png",
-        label: function() {
-            var influxNode = RED.nodes.node(this.influxdb);
-            return this.name || (influxNode ? influxNode.label() + " " + this.query : "influxdb 2 in");
-        },
-        labelStyle: function() {
-            return this.name ? "node_label_italic" : "";
         }
     });
 </script>

--- a/influxdb.html
+++ b/influxdb.html
@@ -77,16 +77,6 @@
             }         
         },
         oneditprepare: function () {
-                
-            //console.log($("#node-config-input-influxdbVersion option:selected").text());
-            //console.log($("#node-config-input-influxdbVersion option:selected").val());
-
-            /*
-            if (typeof this.usetls === 'undefined') {
-                this.usetls = false;
-                $("#node-config-input-usetls").prop("checked", false);
-            }
-            */
             function updateTLSOptions() {
                 if ($("#node-config-input-usetls").is(':checked')) {
                     $("#node-config-row-tls").show();
@@ -135,11 +125,9 @@
                     });
                 }
                 if ($("#node-config-input-influxdbVersion option:selected").val() === '1.8 flux') {
-                    //alert("Handler for .change() 1.8 flux called.");
                     update18FluxOptions();
                 }
                 if ($("#node-config-input-influxdbVersion option:selected").val() === '2.0') {
-                    //alert("Handler for .change() 2.0 flux called.");
                     update20Options();
                 }          
             });
@@ -287,7 +275,6 @@
             }
 
             function update18Options() {                
-                //console.log('update 18 options called!');
                 $("#node-input-row-org").hide();
                 $("#node-input-row-bucket").hide();
                 $("#node-input-row-database").hide();
@@ -298,7 +285,6 @@
             }
 
             function update18FluxOptions() {       
-                //console.log('update 18 Flux options called!');
                 $("#node-input-row-org").hide();
                 $("#node-input-row-bucket").hide();         
                 $("#node-input-row-database").show();
@@ -309,7 +295,6 @@
             }
 
             function update20Options() {
-                //console.log('update 20 options called!');
                 $("#node-input-row-org").show();
                 $("#node-input-row-bucket").show();           
                 $("#node-input-row-database").hide();
@@ -327,16 +312,11 @@
                     var influxDBVersion = influxDBVersionMatches[1];
                 }
                 
-                //console.log(influxDBVersion);
-                
                 if (influxDBVersion === 'v1.8' || influxDBVersion == '') {
-                    //alert("Handler for .change() 1.8 called.");
                     update18Options();
                 } else if (influxDBVersion === 'v1.8 flux') {
-                    //alert("Handler for .change() 1.8 flux called.");
                     update18FluxOptions();                    
                 } else if (influxDBVersion === 'v2.0') {
-                    //alert("Handler for .change() 2.0 called.");
                     update20Options();                    
                 }
             });
@@ -572,22 +552,19 @@
                 $("#advanced-options-div").show();
             }
 
-            function update18Options() {                
-                //console.log('update 18 options called!');                
+            function update18Options() {
                 $("#node-input-row-org").hide();
                 $("#node-input-row-rawOutput").show();
                 $("#node-input-row-enableAdvancedOptions").show();
             }
 
-            function update18FluxOptions() {       
-                //console.log('update 18 Flux options called!');
+            function update18FluxOptions() {                
                 $("#node-input-row-org").hide();
                 $("#node-input-row-rawOutput").hide();
                 $("#node-input-row-enableAdvancedOptions").hide();
             }
 
             function update20Options() {
-                //console.log('update 20 options called!');
                 $("#node-input-row-org").show();
                 $("#node-input-row-rawOutput").hide();
                 $("#node-input-row-enableAdvancedOptions").hide();
@@ -599,18 +576,12 @@
                 var influxDBVersion = '';
                 if (influxDBVersionMatches) {
                     var influxDBVersion = influxDBVersionMatches[1];
-                }
-                
-                //console.log(influxDBVersion);
-                
+                }		    
                 if (influxDBVersion === 'v1.8' || influxDBVersion == '') {
-                    //alert("Handler for .change() 1.8 called.");
                     update18Options();
                 } else if (influxDBVersion === 'v1.8 flux') {
-                    //alert("Handler for .change() 1.8 flux called.");
                     update18FluxOptions();                    
                 } else if (influxDBVersion === 'v2.0') {
-                    //alert("Handler for .change() 2.0 called.");
                     update20Options();                    
                 }
             });

--- a/influxdb.html
+++ b/influxdb.html
@@ -128,7 +128,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb out', {
-        category: 'storage-output',
+        category: 'InfluxDB 18',
         color: "rgb(218, 196, 180)",
         defaults: {
             influxdb: {type: "influxdb", required: true},
@@ -233,7 +233,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb batch', {
-        category: 'storage-output',
+        category: 'InfluxDB 18',
         color: "rgb(218, 196, 180)",
         paletteLabel: 'influx batch',
         defaults: {
@@ -340,7 +340,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('influxdb in', {
-        category: 'storage-input',
+        category: 'InfluxDB 18',
         color: "rgb(218, 196, 180)",
         defaults: {
             influxdb: {type: "influxdb", required: true},
@@ -392,6 +392,338 @@
                 $("#node-input-precision").val("");
                 $("#node-input-retentionPolicy").val("");
             }
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb18flux">
+    <div class="form-row">
+        <label for="node-config-input-url"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.url"></span></label>
+        <input class="input-append-left" type="text" id="node-config-input-url" placeholder="http://localhost:8086">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-username"><i class="fa fa-user"></i> <span data-i18n="node-red:common.label.username"></span></label>
+        <input type="text" id="node-config-input-username">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-password"><i class="fa fa-lock"></i> <span data-i18n="node-red:common.label.password"></span></label>
+        <input type="password" id="node-config-input-password">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>    
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb18flux', {
+        category: 'config',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            url: {value: "http://localhost:8086", required: true},            
+            name: {value: ""}
+        },
+        credentials: {
+            username: {type: "text", required: true},
+            password: {type: "password", required: true}
+        },
+        label: function() {
+            return this.name || this.url;
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb 1.8 flux out">
+    <div class="form-row">
+        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.server"></span></label>
+        <input type="text" id="node-input-influxdb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-database"><i class="fa fa-database"></i> <span data-i18n="influxdb18.label.database"></span></label>
+        <input type="text" id="node-input-database">
+    </div>
+    <div class="form-row">
+        <label for="node-input-measurement"><i style="width: 10px;" class="fa fa-rss"></i> <span data-i18n="influxdb18.label.measurement"></span></label>
+        <input type="text" id="node-input-measurement">
+    </div>
+    <div class="form-row">
+        <label for="node-input-precision"><i class="fa fa-clock-o"></i> <span data-i18n="influxdb18.label.time-precision"></span></label>
+        <select type="text" id="node-input-precision">
+            <option value="ns">Nanoseconds (ns)</option> 
+            <option value="us">Microseconds (us)</option> 
+            <option value="ms">Milliseconds (ms)</option> 
+            <option value="s">Seconds (s)</option>
+        </select>  
+    </div>
+    <div class="form-row">
+        <label for="node-input-retentionPolicy"><i class="fa fa-gavel"></i> <span data-i18n="influxdb18.label.retention-policy"></span></label>
+        <input type="text" id="node-input-retentionPolicy">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-tips" id="node-warning-measurement"><span data-i18n="[html]influxdb18.tip.measurement"></span></div>
+    <div class="form-tips" id="node-warning-retention-policy"><span data-i18n="[html]influxdb18.tip.retention-policy"></span></div>
+</script>
+
+<script type="text/x-red" data-help-name="influxdb 1.8 flux out">
+    <p>A simple influxdb 1.8 output node to write values and tags to an influxdb measurement.</p>
+    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
+    it will be written as a single value to the specified measurement (called <i>value</i>).</p>
+    <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
+    <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
+    the second is the set of named tags.</p>
+    <p>Finally, if <b>msg.payload</b> is an array of arrays, it will be written as a series of points containing fields and tags.</p>
+    <p>If the <i>measurement</i> field is not set in the node configuration, the user can send in data with a specified 
+    measurement name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
+    <p>The options <i>Precision</i> and <i>Retention</i> for time precision and retention policy can be overwritten 
+    using message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p> 
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb 1.8 flux out', {
+        category: 'InfluxDB 18 flux',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            influxdb: {type: "influxdb18flux", required: true},
+            database: {value: "", required: true},            
+            measurement: {value: ""},
+            precision: {value: "ms"},
+            retentionPolicy: {value: ""},
+            name: {value: ""}
+        },
+        inputs: 1,
+        outputs: 0,
+        icon: "influxdb.png",
+        align: "right",
+        label: function() {
+            var influxNode = RED.nodes.node(this.influxdb);
+            return this.name || (influxNode ? influxNode.label() + "/" + this.database + " " + this.measurement : "influxdb 1.8 flux out");
+        },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : "";
+        },
+        oneditprepare: function() {
+            $("#node-input-measurement").change(function () {
+                if($("#node-input-measurement").val() === "") {
+                    $("#node-warning-measurement").show();
+                } else {
+                    $("#node-warning-measurement").hide();
+                }
+            });
+            $("#node-input-retentionPolicy").change(function () {
+                if($("#node-input-retentionPolicy").val() === "") {
+                    $("#node-warning-retention-policy").show();
+                } else {
+                    $("#node-warning-retention-policy").hide();
+                }
+            });
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb 1.8 flux in">
+    <div class="form-row">
+        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb18.label.server"></span></label>
+        <input type="text" id="node-input-influxdb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-query"><i class="fa fa-briefcase"></i> <span data-i18n="influxdb18.label.query"></span></label>
+        <input type="text" id="node-input-query">
+    </div> 
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb18.tip.querytip"></span></div>
+</script>
+
+<script type="text/x-red" data-help-name="influxdb 1.8 flux in">
+    <p>Allows basic queries to be made to an influxdb 1.8 flux time series database.</p>
+    <p>The flux query can be specified in the configuration property or using the property
+    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb 1.8 flux in', {
+        category: 'InfluxDB 18 flux',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            influxdb: {type: "influxdb18flux", required: true},
+            query: {value: ""},
+            name: {value: ""}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "influxdb.png",
+        label: function() {
+            var influxNode = RED.nodes.node(this.influxdb);
+            return this.name || (influxNode ? influxNode.label() + " " + this.query : "influxdb 1.8 flux in");
+        },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : "";
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb2">
+    <div class="form-row">
+        <label for="node-config-input-url"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.url"></span></label>
+        <input class="input-append-left" type="text" id="node-config-input-url" placeholder="http://localhost:9999">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-token"><i class="fa fa-lock"></i> <span data-i18n="influxdb2.label.token"></span></label>
+        <input type="password" id="node-config-input-token">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>    
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb2', {
+        category: 'config',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            url: {value: "http://localhost:9999", required: true},            
+            token: {value: "", required: true},
+            name: {value: ""}
+        },
+        label: function() {
+            return this.name || this.url;
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb 2 out">
+    <div class="form-row">
+        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.server"></span></label>
+        <input type="text" id="node-input-influxdb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb2.label.org"></span></label>
+        <input type="text" id="node-input-org">
+    </div>
+    <div class="form-row">
+        <label for="node-input-bucket"><i class="fa fa-database"></i> <span data-i18n="influxdb2.label.bucket"></span></label>
+        <input type="text" id="node-input-bucket">
+    </div>
+    <div class="form-row">
+        <label for="node-input-measurement"><i style="width: 10px;" class="fa fa-rss"></i> <span data-i18n="influxdb2.label.measurement"></span></label>
+        <input type="text" id="node-input-measurement">
+    </div>
+    <div class="form-row">
+        <label for="node-input-precision"><i class="fa fa-clock-o"></i> <span data-i18n="influxdb2.label.time-precision"></span></label>
+        <select type="text" id="node-input-precision">
+            <option value="ns">Nanoseconds (ns)</option> 
+            <option value="us">Microseconds (us)</option> 
+            <option value="ms">Milliseconds (ms)</option> 
+            <option value="s">Seconds (s)</option>
+        </select>  
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-tips" id="node-warning-measurement"><span data-i18n="[html]influxdb2.tip.measurement"></span></div>    
+</script>
+
+<script type="text/x-red" data-help-name="influxdb 2 out">
+    <p>A simple influxdb 2 output node to write values and tags to an influxdb measurement.</p>
+    <p>The fields and tags to write are in <b>msg.payload</b>. If <b>msg.payload</b> is a string, number, or boolean, 
+    it will be written as a single value to the specified measurement (called <i>value</i>).</p>
+    <p>If <b>msg.payload</b> is an object containing multiple properties, the fields will be written to the measurement.</p>
+    <p>If <b>msg.payload</b> is an array containing two objects, the first object will be written as the set of named fields, 
+    the second is the set of named tags.</p>
+    <p>Finally, if <b>msg.payload</b> is an array of arrays, it will be written as a series of points containing fields and tags.</p>
+    <p>If the <i>measurement</i> field is not set in the node configuration, the user can send in data with a specified 
+    measurement name in <b>msg.measurement</b> to overwrite the <i>measurement</i> field in the configuration of the node.</p>
+    <p>The options <i>Precision</i> and <i>Retention</i> for time precision and retention policy can be overwritten 
+    using message properties <b>msg.precision</b> and <b>msg.retentionPolicy</b>.</p> 
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb 2 out', {
+        category: 'InfluxDB 2',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            influxdb: {type: "influxdb2", required: true},
+            org: {value: "", required: true},
+            bucket: {value: "", required: true},  
+            measurement: {value: ""},
+            precision: {value: "ms"},
+            name: {value: ""}
+        },
+        inputs: 1,
+        outputs: 0,
+        icon: "influxdb.png",
+        align: "right",
+        label: function() {
+            var influxNode = RED.nodes.node(this.influxdb);
+            return this.name || (influxNode ? influxNode.label() + "/" + this.bucket + " " + this.measurement : "influxdb 2 out");
+        },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : "";
+        },
+        oneditprepare: function() {
+            $("#node-input-measurement").change(function () {
+                if($("#node-input-measurement").val() === "") {
+                    $("#node-warning-measurement").show();
+                } else {
+                    $("#node-warning-measurement").hide();
+                }
+            });
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="influxdb 2 in">
+    <div class="form-row">
+        <label for="node-input-influxdb"><i class="fa fa-server"></i> <span data-i18n="influxdb2.label.server"></span></label>
+        <input type="text" id="node-input-influxdb">
+    </div>
+    <div class="form-row">
+        <label for="node-input-org"><i class="fa fa-sitemap"></i> <span data-i18n="influxdb2.label.org"></span></label>
+        <input type="text" id="node-input-org">
+    </div>
+    <div class="form-row">
+        <label for="node-input-query"><i class="fa fa-briefcase"></i> <span data-i18n="influxdb2.label.query"></span></label>
+        <input type="text" id="node-input-query">
+    </div> 
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-tips" id="node-warning" style="display: none"><span data-i18n="[html]influxdb2.tip.querytip"></span></div>
+</script>
+
+<script type="text/x-red" data-help-name="influxdb 2 in">
+    <p>Allows basic queries to be made to an influxdb 2 time series database.</p>
+    <p>The flux query can be specified in the configuration property or using the property
+    <b>msg.query</b>. The results will be returned in <b>msg.payload</b>.</p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('influxdb 2 in', {
+        category: 'InfluxDB 2',
+        color: "rgb(218, 196, 180)",
+        defaults: {
+            influxdb: {type: "influxdb2", required: true},
+            org: {value: "", required: true},
+            query: {value: ""},
+            name: {value: ""}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "influxdb.png",
+        label: function() {
+            var influxNode = RED.nodes.node(this.influxdb);
+            return this.name || (influxNode ? influxNode.label() + " " + this.query : "influxdb 2 in");
+        },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : "";
         }
     });
 </script>

--- a/influxdb.js
+++ b/influxdb.js
@@ -1,171 +1,331 @@
 var _ = require('lodash');
 
-module.exports = function(RED) {
+module.exports = function (RED) {
     "use strict";
     var Influx = require('influx');
     var { InfluxDB, Point } = require('@influxdata/influxdb-client');
 
     /**
-     * Config node.  Currently we only connect to one host.
+     * Config node. Currently we only connect to one host.
      */
     function InfluxConfigNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.hostname = n.hostname;
         this.port = n.port;
-        this.database= n.database;
+        this.database = n.database;
         this.name = n.name;
-        this.usetls = n.usetls;
-        if (typeof this.usetls === 'undefined') {
-            this.usetls = false;
+
+        var clientOptions = null;
+        if (n.influxdbVersion === '1.8') {
+            this.usetls = n.usetls;
+            if (typeof this.usetls === 'undefined') {
+                this.usetls = false;
+            }
+            // for backward compatibility with old 'protocol' setting
+            if (n.protocol === 'https') {
+                this.usetls = true;
+            }
+            if (this.usetls && n.tls) {
+                var tlsNode = RED.nodes.getNode(n.tls);
+                if (tlsNode) {
+                    this.hostOptions = {};
+                    tlsNode.addTLSOptions(this.hostOptions);
+                }
+            }
+
+            this.client = new Influx.InfluxDB({
+                hosts: [{
+                    host: this.hostname,
+                    port: this.port,
+                    protocol: this.usetls ? "https" : "http",
+                    options: this.hostOptions
+                }],
+                database: this.database,
+                username: this.credentials.username,
+                password: this.credentials.password
+            });
+        } else if (n.influxdbVersion === '1.8 flux') {
+            var token = `${this.credentials.username}:${this.credentials.password}`;
+            clientOptions = {
+                url: n.url,
+                token: token
+            }
+
+            this.client = new InfluxDB(clientOptions);
+        } else if (n.influxdbVersion === '2.0') {
+            clientOptions = {
+                url: n.url,
+                token: this.credentials.token
+            }
+
+            this.client = new InfluxDB(clientOptions);
         }
-        // for backward compatibility with old 'protocol' setting
-        if (n.protocol === 'https') {
-            this.usetls = true;
+
+        this.influxdbVersion = n.influxdbVersion;
+    }
+
+    RED.nodes.registerType("influxdb", InfluxConfigNode, {
+        credentials: {
+            username: { type: "text" },
+            password: { type: "password" },
+            token: { type: "password" }
         }
-        if (this.usetls && n.tls) {
-            var tlsNode = RED.nodes.getNode(n.tls);
-            if (tlsNode) {
-                this.hostOptions = {};
-                tlsNode.addTLSOptions(this.hostOptions);
+    });
+
+    function addFieldsToPoint(point, fields) {
+        for (const prop in fields) {
+            const value = fields[prop];
+            if (prop === 'time') {
+                point.timestamp(value);
+            } else if (typeof value === 'number') {
+                if (Number.isInteger(value)) {
+                    point.intField(prop, value);
+                } else {
+                    point.floatField(prop, value);
+                }
+            } else if (typeof value === 'string') {
+                point.stringField(prop, value);
+            } else if (typeof value === 'boolean') {
+                point.booleanField(prop, value);
+            }
+        }
+    }
+
+    function writePoints(msg, node) {
+        node.client.closed == false ? null : node.client.closed = false;
+        var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
+        if (!measurement) {
+            node.error(RED._("influxdb.errors.nomeasurement"), msg);
+            return;
+        }
+        var point;
+        if (_.isArray(msg.payload) && msg.payload.length > 0) {
+            // array of arrays
+            if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
+                msg.payload.forEach(element => {
+                    point = new Point(measurement);
+
+                    var fields = element[0];
+                    addFieldsToPoint(point, fields);
+
+                    var tags = element[1];
+                    for (const prop in tags) {
+                        point.tag(prop, tags[prop]);
+                    }
+                    node.client.writePoint(point);
+                });
+            } else {
+                // array of non-arrays, assume one point with both fields and tags
+                point = new Point(measurement);
+
+                var fields = msg.payload[0];
+                addFieldsToPoint(point, fields);
+
+                const tags = msg.payload[1];
+                for (const prop in tags) {
+                    point.tag(prop, tags[prop]);
+                }
+
+                node.client.writePoint(point)
+            }
+        } else {
+            if (_.isPlainObject(msg.payload)) {
+                point = new Point(measurement);
+                var fields = msg.payload;
+                addFieldsToPoint(point, fields);
+                node.client.writePoint(point);
+            } else {
+                // just a value
+                point = new Point(measurement);
+                var value = msg.payload;
+                if (typeof value === 'number') {
+                    if (Number.isInteger(value)) {
+                        point.intField('value', value);
+                    } else {
+                        point.floatField('value', value);
+                    }
+                } else if (typeof value === 'string') {
+                    point.stringField('value', value);
+                } else if (typeof value === 'boolean') {
+                    point.booleanField('value', value);
+                }
+                node.client.writePoint(point);
             }
         }
 
-        this.client = new Influx.InfluxDB({
-            hosts: [ {
-                host: this.hostname,
-                port: this.port,
-                protocol: this.usetls ? "https" : "http",
-                options: this.hostOptions
-                }
-            ],
-            database: this.database,
-            username: this.credentials.username,
-            password: this.credentials.password
-        });
+        node.client
+            .close()
+            .catch(error => {
+                msg.influx_error = {
+                    errorMessage: error
+                };
+                node.error(error, msg);
+            })
     }
 
-    RED.nodes.registerType("influxdb",InfluxConfigNode,{
-        credentials: {
-            username: {type:"text"},
-            password: {type: "password"}
+    function queryRows(msg, node) {
+        var query = msg.hasOwnProperty('query') ? msg.query : node.query;
+        if (!query) {
+            node.error(RED._("influxdb18.errors.noquery"), msg);
+            return;
         }
-    });
+        var output = [];
+        node.client.queryRows(query, {
+            next(row, tableMeta) {
+                var o = tableMeta.toObject(row)
+                output.push(o);
+            },
+            error(error) {
+                msg.influx_error = {
+                    errorMessage: error
+                };
+                node.error(error, msg);
+            },
+            complete() {
+                msg.payload = output;
+                node.send(msg);
+            },
+        })
+    }
 
     /**
      * Output node to write to an influxdb measurement
      */
     function InfluxOutNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.measurement = n.measurement;
         this.influxdb = n.influxdb;
         this.precision = n.precision;
         this.retentionPolicy = n.retentionPolicy;
         this.influxdbConfig = RED.nodes.getNode(this.influxdb);
+        this.database = n.database;
+        this.precisionV18FluxV20 = n.precisionV18FluxV20;
+        this.retentionPolicyV18Flux = n.retentionPolicyV18Flux;
+        this.org = n.org;
+        this.bucket = n.bucket;
 
         if (this.influxdbConfig) {
-            var node = this;
-            var client = this.influxdbConfig.client;
+            if (this.influxdbConfig.influxdbVersion === '1.8') {
+                var node = this;
+                var client = this.influxdbConfig.client;
 
-            node.on("input",function(msg) {
-                var measurement;
-                var writeOptions = {};
-                var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
-                if (!measurement) {
-                    node.error(RED._("influxdb.errors.nomeasurement"),msg);
-                    return;                
-                }
-                var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
-                var retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
+                node.on("input", function (msg) {
+                    var measurement;
+                    var writeOptions = {};
+                    var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
+                    if (!measurement) {
+                        node.error(RED._("influxdb.errors.nomeasurement"), msg);
+                        return;
+                    }
+                    var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
+                    var retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
 
-                if (precision) {
-                    writeOptions.precision = precision;
-                }
+                    if (precision) {
+                        writeOptions.precision = precision;
+                    }
 
-                if (retentionPolicy) {
-                    writeOptions.retentionPolicy = retentionPolicy;
-                }
-                
-                // format payload to match new writePoints API
-                var points = [];
-                var point;
-                var timestamp;
-                if (_.isArray(msg.payload) && msg.payload.length > 0) {
-                    // array of arrays
-                    if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
-                        msg.payload.forEach(function(nodeRedPoint) {
+                    if (retentionPolicy) {
+                        writeOptions.retentionPolicy = retentionPolicy;
+                    }
+
+                    // format payload to match new writePoints API
+                    var points = [];
+                    var point;
+                    var timestamp;
+                    if (_.isArray(msg.payload) && msg.payload.length > 0) {
+                        // array of arrays
+                        if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
+                            msg.payload.forEach(function (nodeRedPoint) {
+                                point = {
+                                    measurement: measurement,
+                                    fields: nodeRedPoint[0],
+                                    tags: nodeRedPoint[1]
+                                }
+                                if (point.fields.time) {
+                                    point.timestamp = point.fields.time;
+                                    delete point.fields.time;
+                                }
+                                points.push(point);
+                            });
+                        } else {
+                            // array of non-arrays, assume one point with both fields and tags
                             point = {
                                 measurement: measurement,
-                                fields: nodeRedPoint[0],
-                                tags: nodeRedPoint[1]
-                            }
+                                fields: msg.payload[0],
+                                tags: msg.payload[1]
+                            };
                             if (point.fields.time) {
                                 point.timestamp = point.fields.time;
                                 delete point.fields.time;
                             }
                             points.push(point);
-                        });
+                        }
                     } else {
-                        // array of non-arrays, assume one point with both fields and tags
-                        point = {
-                            measurement: measurement,
-                            fields: msg.payload[0],
-                            tags: msg.payload[1]
-                        };
+                        if (_.isPlainObject(msg.payload)) {
+                            point = {
+                                measurement: measurement,
+                                fields: msg.payload
+                            };
+                        } else {
+                            // just a value
+                            point = {
+                                measurement: measurement,
+                                fields: { value: msg.payload }
+                            };
+                        }
                         if (point.fields.time) {
                             point.timestamp = point.fields.time;
                             delete point.fields.time;
                         }
                         points.push(point);
                     }
-                } else {
-                    if (_.isPlainObject(msg.payload)) {
-                        point = {
-                            measurement: measurement,
-                            fields: msg.payload
-                        };
-                    } else {
-                        // just a value
-                        point = {
-                            measurement: measurement,
-                            fields: {value:msg.payload}
-                        };
-                    }
-                    if (point.fields.time) {
-                        point.timestamp = point.fields.time;
-                        delete point.fields.time;
-                    }
-                    points.push(point);
-                }
 
-                client.writePoints(points, writeOptions).catch(function(err) {
-                    msg.influx_error = {
-                        statusCode : err.res ? err.res.statusCode : 503
-                    }
-                    node.error(err,msg);
+                    client.writePoints(points, writeOptions).catch(function (err) {
+                        msg.influx_error = {
+                            statusCode: err.res ? err.res.statusCode : 503
+                        }
+                        node.error(err, msg);
+                    });
                 });
-            });
+            } else if (this.influxdbConfig.influxdbVersion === '1.8 flux') {
+                let retentionPolicy = this.retentionPolicyV18Flux ? this.retentionPolicyV18Flux : 'autogen';
+                let bucket = `${this.database}/${retentionPolicy}`;
+                this.client = this.influxdbConfig.client.getWriteApi('', bucket, this.precisionV18FluxV20);
+                var node = this;
+
+                node.on("input", function (msg) {
+                    writePoints(msg, node);
+                });
+            } else if (this.influxdbConfig.influxdbVersion === '2.0') {
+                this.client = this.influxdbConfig.client.getWriteApi(this.org, this.bucket, this.precisionV18FluxV20);
+                var node = this;
+
+                node.on("input", function (msg) {
+                    writePoints(msg, node);
+                });
+            }
         } else {
             this.error(RED._("influxdb.errors.missingconfig"));
         }
     }
 
-    RED.nodes.registerType("influxdb out",InfluxOutNode);
+    RED.nodes.registerType("influxdb out", InfluxOutNode);
 
     /**
      * Output node to write batches of points to influxdb
      */
     function InfluxBatchNode(n) {
-        RED.nodes.createNode(this,n);
+        RED.nodes.createNode(this, n);
         this.influxdb = n.influxdb;
         this.precision = n.precision;
         this.retentionPolicy = n.retentionPolicy;
         this.influxdbConfig = RED.nodes.getNode(this.influxdb);
 
-        if (this.influxdbConfig) {
+        if (this.influxdbConfig && this.influxdbConfig.influxdbVersion === '1.8') {
             var node = this;
             var client = this.influxdbConfig.client;
 
-            node.on("input",function(msg) {
+            node.on("input", function (msg) {
                 var writeOptions = {};
                 var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
                 var retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
@@ -178,11 +338,11 @@ module.exports = function(RED) {
                     writeOptions.retentionPolicy = retentionPolicy;
                 }
 
-                client.writePoints(msg.payload, writeOptions).catch(function(err) {
+                client.writePoints(msg.payload, writeOptions).catch(function (err) {
                     msg.influx_error = {
-                        statusCode : err.res ? err.res.statusCode : 503
+                        statusCode: err.res ? err.res.statusCode : 503
                     }
-                    node.error(err,msg);
+                    node.error(err, msg);
                 });
             });
         } else {
@@ -190,7 +350,7 @@ module.exports = function(RED) {
         }
     }
 
-    RED.nodes.registerType("influxdb batch",InfluxBatchNode);
+    RED.nodes.registerType("influxdb batch", InfluxBatchNode);
 
     /**
      * Input node to make queries to influxdb
@@ -203,374 +363,76 @@ module.exports = function(RED) {
         this.retentionPolicy = n.retentionPolicy;
         this.rawOutput = n.rawOutput;
         this.influxdbConfig = RED.nodes.getNode(this.influxdb);
+        this.org = n.org;
+
         if (this.influxdbConfig) {
-            var node = this;
-            var client = this.influxdbConfig.client;
+            if (this.influxdbConfig.influxdbVersion === '1.8') {
+                var node = this;
+                var client = this.influxdbConfig.client;
 
-            node.on("input", function (msg) {
-                var query;
-                var rawOutput;
-                var queryOptions = {};
-                var precision;
-                var retentionPolicy;
+                node.on("input", function (msg) {
+                    var query;
+                    var rawOutput;
+                    var queryOptions = {};
+                    var precision;
+                    var retentionPolicy;
 
-                query = msg.hasOwnProperty('query') ? msg.query : node.query;
-                if (!query) {
-                    node.error(RED._("influxdb.errors.noquery"), msg);
-                    return;                  
-                }
-
-                rawOutput = msg.hasOwnProperty('rawOutput') ? msg.rawOutput : node.rawOutput;
-                precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
-                retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
-
-                if (precision) {
-                    queryOptions.precision = precision;
-                }
-
-                if (retentionPolicy) {
-                    queryOptions.retentionPolicy = retentionPolicy;
-                }
-
-                if (rawOutput) {
-                    var queryPromise = client.queryRaw(query, queryOptions);
-                } else {
-                    var queryPromise = client.query(query, queryOptions);
-                }
-
-                queryPromise.then(function (results) {
-                    msg.payload = results;
-                    node.send(msg);
-                }).catch(function (err) {
-                    msg.influx_error = {
-                        statusCode : err.res ? err.res.statusCode : 503
+                    query = msg.hasOwnProperty('query') ? msg.query : node.query;
+                    if (!query) {
+                        node.error(RED._("influxdb.errors.noquery"), msg);
+                        return;
                     }
-                    node.error(err, msg);
+
+                    rawOutput = msg.hasOwnProperty('rawOutput') ? msg.rawOutput : node.rawOutput;
+                    precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
+                    retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
+
+                    if (precision) {
+                        queryOptions.precision = precision;
+                    }
+
+                    if (retentionPolicy) {
+                        queryOptions.retentionPolicy = retentionPolicy;
+                    }
+
+                    if (rawOutput) {
+                        var queryPromise = client.queryRaw(query, queryOptions);
+                    } else {
+                        var queryPromise = client.query(query, queryOptions);
+                    }
+
+                    queryPromise.then(function (results) {
+                        msg.payload = results;
+                        node.send(msg);
+                    }).catch(function (err) {
+                        msg.influx_error = {
+                            statusCode: err.res ? err.res.statusCode : 503
+                        }
+                        node.error(err, msg);
+                    });
                 });
-            });
+
+            } else if (this.influxdbConfig.influxdbVersion === '1.8 flux') {
+                this.client = this.influxdbConfig.client.getQueryApi('');
+                var node = this;
+
+                node.on("input", function (msg) {
+                    queryRows(msg, node);
+                });
+
+            } else if (this.influxdbConfig.influxdbVersion === '2.0') {
+                this.client = this.influxdbConfig.client.getQueryApi(this.org);
+                var node = this;
+
+                node.on("input", function (msg) {
+                    queryRows(msg, node);
+                });
+
+            }
         } else {
             this.error(RED._("influxdb.errors.missingconfig"));
         }
     }
-    RED.nodes.registerType("influxdb in",InfluxInNode);
 
-    function addFieldsToPoint(point, fields) {
-        for (const prop in fields) {
-          const value = fields[prop];
-          if (prop === 'time') {
-            point.timestamp(value);
-          } else if (typeof value === 'number') {
-            if (Number.isInteger(value)) {
-              point.intField(prop, value);
-            } else {
-              point.floatField(prop, value);
-            }
-          } else if (typeof value === 'string') {
-            point.stringField(prop, value);
-          } else if (typeof value === 'boolean') {
-            point.booleanField(prop, value);
-          }
-        }
-      }
-
-    /**
-     * Config node for InfluxDB 1.8 flux
-     */
-    function Influx18FluxConfigNode(n) {
-        RED.nodes.createNode(this,n);
-        var token = `${this.credentials.username}:${this.credentials.password}`;
-        var clientOptions = {
-            url: n.url,
-            token: token
-        }
-        this.influxDB = new InfluxDB(clientOptions);
-    }
-    RED.nodes.registerType("influxdb18flux",Influx18FluxConfigNode,{
-        credentials: {
-            username: {type:"text"},
-            password: {type: "password"}
-        }
-    });
-
-    /**
-     * Output node to write to an InfluxDB 1.8 flux measurement
-     */
-    function Influx18FluxOutNode(n) {
-        RED.nodes.createNode(this,n);
-        this.influxdbConfig = RED.nodes.getNode(n.influxdb);        
-        this.measurement = n.measurement;
-        this.precision = n.precision;
-        var retentionPolicy = n.retentionPolicy ? n.retentionPolicy : 'autogen';
-        this.bucket = `${n.database}/${retentionPolicy}`;
-
-        if (this.influxdbConfig) {
-            var node = this;
-            node.on("input",function(msg) {                
-                var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
-                var client = this.influxdbConfig.influxDB.getWriteApi('', node.bucket, precision);
-                var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
-                if (!measurement) {
-                    node.error(RED._("influxdb18.errors.nomeasurement"),msg);
-                    return;                
-                }
-                var point;
-                if (_.isArray(msg.payload) && msg.payload.length > 0) {
-                    // array of arrays
-                    if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
-                        msg.payload.forEach(element => {  
-                            point = new Point(measurement);                            
-                            
-                            var fields = element[0];
-                            addFieldsToPoint(point, fields);
-                          
-                            var tags = element[1];
-                            for (const prop in tags) {
-                              point.tag(prop, tags[prop]);
-                            }
-                            client.writePoint(point);
-                          });                          
-                    } else {
-                        // array of non-arrays, assume one point with both fields and tags
-                        point = new Point(measurement);
-
-                        var fields = msg.payload[0];
-                        addFieldsToPoint(point, fields);
-
-                        const tags = msg.payload[1];
-                        for (const prop in tags) {
-                            point.tag(prop, tags[prop]);
-                        }
-
-                        client.writePoint(point)
-                    }
-                } else {
-                    if (_.isPlainObject(msg.payload)) {
-                        point = new Point(measurement);
-                        var fields = msg.payload;
-                        addFieldsToPoint(point, fields);
-                        client.writePoint(point);
-                    } else {
-                        // just a value
-                        point = new Point(measurement);
-                        var value = msg.payload;
-                        if (typeof value === 'number') {
-                            if (Number.isInteger(value)) {
-                              point.intField('value', value);
-                            } else {
-                              point.floatField('value', value);
-                            }
-                          } else if (typeof value === 'string') {
-                            point.stringField('value', value);
-                          } else if (typeof value === 'boolean') {
-                            point.booleanField('value', value);
-                          }
-                          client.writePoint(point);
-                    }
-                }
-                
-                client
-                    .close()
-                    .catch(error => {
-                        msg.influx_error = {
-                            errorMessage: error
-                        };
-                        node.error(error, msg);
-                    })
-            });
-        } else {
-            this.error(RED._("influxdb18.errors.missingconfig"));
-        }
-    }
-    RED.nodes.registerType("influxdb 1.8 flux out",Influx18FluxOutNode);
-    
-    /**
-     * Input node to make queries to InfluxDB 1.8 flux
-     */
-    function Influx18FluxInNode(n) {
-        RED.nodes.createNode(this, n);
-        this.influxdbConfig = RED.nodes.getNode(n.influxdb);
-        this.query = n.query;
-
-        if (this.influxdbConfig) {
-            var node = this;
-            var client = this.influxdbConfig.client;
-
-            node.on("input", function (msg) {                
-                var client = this.influxdbConfig.influxDB.getQueryApi('');                
-                var query = msg.hasOwnProperty('query') ? msg.query : node.query;
-                if (!query) {
-                    node.error(RED._("influxdb18.errors.noquery"), msg);
-                    return;                  
-                }
-                var output = [];
-                client.queryRows(query, {
-                    next(row, tableMeta) {
-                        var o = tableMeta.toObject(row)
-                        output.push(o);
-                    },
-                    error(error) {
-                        msg.influx_error = {
-                            errorMessage: error
-                        };
-                        node.error(error, msg);
-                    },
-                    complete() {
-                        msg.payload = output;
-                        node.send(msg);
-                    },
-                })
-            });
-        } else {
-            this.error(RED._("influxdb18.errors.missingconfig"));
-        }
-    }
-    RED.nodes.registerType("influxdb 1.8 flux in",Influx18FluxInNode);
-
-    /**
-     * Config node for InfluxDB 2
-     */
-    function Influx2ConfigNode(n) {
-        RED.nodes.createNode(this,n);
-        var clientOptions = {
-            url: n.url,
-            token: n.token
-        }
-        this.influxDB = new InfluxDB(clientOptions);        
-    }
-    RED.nodes.registerType("influxdb2",Influx2ConfigNode);
-
-    /**
-     * Output node to write to an InfluxDB 2 measurement
-     */
-    function Influx2OutNode(n) {
-        RED.nodes.createNode(this,n);
-        this.influxdbConfig = RED.nodes.getNode(n.influxdb);        
-        this.org = n.org;
-        this.bucket = n.bucket;
-        this.measurement = n.measurement;
-        this.precision = n.precision;        
-
-        if (this.influxdbConfig) {
-            var node = this;
-            node.on("input",function(msg) {                
-                var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
-                var client = this.influxdbConfig.influxDB.getWriteApi(node.org, node.bucket, precision);
-                var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
-                if (!measurement) {
-                    node.error(RED._("influxdb2.errors.nomeasurement"),msg);
-                    return;                
-                }
-                var point;
-                if (_.isArray(msg.payload) && msg.payload.length > 0) {
-                    // array of arrays
-                    if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
-                        msg.payload.forEach(element => {  
-                            point = new Point(measurement);                            
-                            
-                            var fields = element[0];
-                            addFieldsToPoint(point, fields);
-                          
-                            var tags = element[1];
-                            for (const prop in tags) {
-                              point.tag(prop, tags[prop]);
-                            }
-                            client.writePoint(point);
-                          });                          
-                    } else {
-                        // array of non-arrays, assume one point with both fields and tags
-                        point = new Point(measurement);
-
-                        var fields = msg.payload[0];
-                        addFieldsToPoint(point, fields);
-
-                        const tags = msg.payload[1];
-                        for (const prop in tags) {
-                            point.tag(prop, tags[prop]);
-                        }
-
-                        client.writePoint(point)
-                    }
-                } else {
-                    if (_.isPlainObject(msg.payload)) {
-                        point = new Point(measurement);
-                        var fields = msg.payload;
-                        addFieldsToPoint(point, fields);
-                        client.writePoint(point);
-                    } else {
-                        // just a value
-                        point = new Point(measurement);
-                        var value = msg.payload;
-                        if (typeof value === 'number') {
-                            if (Number.isInteger(value)) {
-                              point.intField('value', value);
-                            } else {
-                              point.floatField('value', value);
-                            }
-                          } else if (typeof value === 'string') {
-                            point.stringField('value', value);
-                          } else if (typeof value === 'boolean') {
-                            point.booleanField('value', value);
-                          }
-                          client.writePoint(point);
-                    }
-                }
-                
-                client
-                    .close()
-                    .catch(error => {
-                        msg.influx_error = {
-                            errorMessage: error
-                        };
-                        node.error(error, msg);
-                    })
-            });
-        } else {
-            this.error(RED._("influxdb2.errors.missingconfig"));
-        }
-    }
-    RED.nodes.registerType("influxdb 2 out",Influx2OutNode);
-    
-    /**
-     * Input node to make queries to InfluxDB 2
-     */
-    function Influx2InNode(n) {
-        RED.nodes.createNode(this, n);
-        this.influxdbConfig = RED.nodes.getNode(n.influxdb);
-        this.org = n.org;
-        this.query = n.query;
-
-        if (this.influxdbConfig) {
-            var node = this;
-            var client = this.influxdbConfig.client;
-
-            node.on("input", function (msg) {                
-                var client = this.influxdbConfig.influxDB.getQueryApi(node.org);                
-                var query = msg.hasOwnProperty('query') ? msg.query : node.query;
-                if (!query) {
-                    node.error(RED._("influxdb2.errors.noquery"), msg);
-                    return;                  
-                }
-                var output = [];
-                client.queryRows(query, {
-                    next(row, tableMeta) {
-                        var o = tableMeta.toObject(row)
-                        output.push(o);
-                    },
-                    error(error) {
-                        msg.influx_error = {
-                            errorMessage: error
-                        };
-                        node.error(error, msg);
-                    },
-                    complete() {
-                        msg.payload = output;
-                        node.send(msg);
-                    },
-                })
-            });
-        } else {
-            this.error(RED._("influxdb2.errors.missingconfig"));
-        }
-    }
-    RED.nodes.registerType("influxdb 2 in",Influx2InNode);
+    RED.nodes.registerType("influxdb in", InfluxInNode);
 }

--- a/influxdb.js
+++ b/influxdb.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 module.exports = function(RED) {
     "use strict";
     var Influx = require('influx');
+    var { InfluxDB, Point } = require('@influxdata/influxdb-client');
 
     /**
      * Config node.  Currently we only connect to one host.
@@ -252,4 +253,324 @@ module.exports = function(RED) {
         }
     }
     RED.nodes.registerType("influxdb in",InfluxInNode);
+
+    function addFieldsToPoint(point, fields) {
+        for (const prop in fields) {
+          const value = fields[prop];
+          if (prop === 'time') {
+            point.timestamp(value);
+          } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+              point.intField(prop, value);
+            } else {
+              point.floatField(prop, value);
+            }
+          } else if (typeof value === 'string') {
+            point.stringField(prop, value);
+          } else if (typeof value === 'boolean') {
+            point.booleanField(prop, value);
+          }
+        }
+      }
+
+    /**
+     * Config node for InfluxDB 1.8 flux
+     */
+    function Influx18FluxConfigNode(n) {
+        RED.nodes.createNode(this,n);
+        var token = `${this.credentials.username}:${this.credentials.password}`;
+        var clientOptions = {
+            url: n.url,
+            token: token
+        }
+        this.influxDB = new InfluxDB(clientOptions);
+    }
+    RED.nodes.registerType("influxdb18flux",Influx18FluxConfigNode,{
+        credentials: {
+            username: {type:"text"},
+            password: {type: "password"}
+        }
+    });
+
+    /**
+     * Output node to write to an InfluxDB 1.8 flux measurement
+     */
+    function Influx18FluxOutNode(n) {
+        RED.nodes.createNode(this,n);
+        this.influxdbConfig = RED.nodes.getNode(n.influxdb);        
+        this.measurement = n.measurement;
+        this.precision = n.precision;
+        var retentionPolicy = n.retentionPolicy ? n.retentionPolicy : 'autogen';
+        this.bucket = `${n.database}/${retentionPolicy}`;
+
+        if (this.influxdbConfig) {
+            var node = this;
+            node.on("input",function(msg) {                
+                var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
+                var client = this.influxdbConfig.influxDB.getWriteApi('', node.bucket, precision);
+                var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
+                if (!measurement) {
+                    node.error(RED._("influxdb18.errors.nomeasurement"),msg);
+                    return;                
+                }
+                var point;
+                if (_.isArray(msg.payload) && msg.payload.length > 0) {
+                    // array of arrays
+                    if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
+                        msg.payload.forEach(element => {  
+                            point = new Point(measurement);                            
+                            
+                            var fields = element[0];
+                            addFieldsToPoint(point, fields);
+                          
+                            var tags = element[1];
+                            for (const prop in tags) {
+                              point.tag(prop, tags[prop]);
+                            }
+                            client.writePoint(point);
+                          });                          
+                    } else {
+                        // array of non-arrays, assume one point with both fields and tags
+                        point = new Point(measurement);
+
+                        var fields = msg.payload[0];
+                        addFieldsToPoint(point, fields);
+
+                        const tags = msg.payload[1];
+                        for (const prop in tags) {
+                            point.tag(prop, tags[prop]);
+                        }
+
+                        client.writePoint(point)
+                    }
+                } else {
+                    if (_.isPlainObject(msg.payload)) {
+                        point = new Point(measurement);
+                        var fields = msg.payload;
+                        addFieldsToPoint(point, fields);
+                        client.writePoint(point);
+                    } else {
+                        // just a value
+                        point = new Point(measurement);
+                        var value = msg.payload;
+                        if (typeof value === 'number') {
+                            if (Number.isInteger(value)) {
+                              point.intField('value', value);
+                            } else {
+                              point.floatField('value', value);
+                            }
+                          } else if (typeof value === 'string') {
+                            point.stringField('value', value);
+                          } else if (typeof value === 'boolean') {
+                            point.booleanField('value', value);
+                          }
+                          client.writePoint(point);
+                    }
+                }
+                
+                client
+                    .close()
+                    .catch(error => {
+                        msg.influx_error = {
+                            errorMessage: error
+                        };
+                        node.error(error, msg);
+                    })
+            });
+        } else {
+            this.error(RED._("influxdb18.errors.missingconfig"));
+        }
+    }
+    RED.nodes.registerType("influxdb 1.8 flux out",Influx18FluxOutNode);
+    
+    /**
+     * Input node to make queries to InfluxDB 1.8 flux
+     */
+    function Influx18FluxInNode(n) {
+        RED.nodes.createNode(this, n);
+        this.influxdbConfig = RED.nodes.getNode(n.influxdb);
+        this.query = n.query;
+
+        if (this.influxdbConfig) {
+            var node = this;
+            var client = this.influxdbConfig.client;
+
+            node.on("input", function (msg) {                
+                var client = this.influxdbConfig.influxDB.getQueryApi('');                
+                var query = msg.hasOwnProperty('query') ? msg.query : node.query;
+                if (!query) {
+                    node.error(RED._("influxdb18.errors.noquery"), msg);
+                    return;                  
+                }
+                var output = [];
+                client.queryRows(query, {
+                    next(row, tableMeta) {
+                        var o = tableMeta.toObject(row)
+                        output.push(o);
+                    },
+                    error(error) {
+                        msg.influx_error = {
+                            errorMessage: error
+                        };
+                        node.error(error, msg);
+                    },
+                    complete() {
+                        msg.payload = output;
+                        node.send(msg);
+                    },
+                })
+            });
+        } else {
+            this.error(RED._("influxdb18.errors.missingconfig"));
+        }
+    }
+    RED.nodes.registerType("influxdb 1.8 flux in",Influx18FluxInNode);
+
+    /**
+     * Config node for InfluxDB 2
+     */
+    function Influx2ConfigNode(n) {
+        RED.nodes.createNode(this,n);
+        var clientOptions = {
+            url: n.url,
+            token: n.token
+        }
+        this.influxDB = new InfluxDB(clientOptions);        
+    }
+    RED.nodes.registerType("influxdb2",Influx2ConfigNode);
+
+    /**
+     * Output node to write to an InfluxDB 2 measurement
+     */
+    function Influx2OutNode(n) {
+        RED.nodes.createNode(this,n);
+        this.influxdbConfig = RED.nodes.getNode(n.influxdb);        
+        this.org = n.org;
+        this.bucket = n.bucket;
+        this.measurement = n.measurement;
+        this.precision = n.precision;        
+
+        if (this.influxdbConfig) {
+            var node = this;
+            node.on("input",function(msg) {                
+                var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
+                var client = this.influxdbConfig.influxDB.getWriteApi(node.org, node.bucket, precision);
+                var measurement = msg.hasOwnProperty('measurement') ? msg.measurement : node.measurement;
+                if (!measurement) {
+                    node.error(RED._("influxdb2.errors.nomeasurement"),msg);
+                    return;                
+                }
+                var point;
+                if (_.isArray(msg.payload) && msg.payload.length > 0) {
+                    // array of arrays
+                    if (_.isArray(msg.payload[0]) && msg.payload[0].length > 0) {
+                        msg.payload.forEach(element => {  
+                            point = new Point(measurement);                            
+                            
+                            var fields = element[0];
+                            addFieldsToPoint(point, fields);
+                          
+                            var tags = element[1];
+                            for (const prop in tags) {
+                              point.tag(prop, tags[prop]);
+                            }
+                            client.writePoint(point);
+                          });                          
+                    } else {
+                        // array of non-arrays, assume one point with both fields and tags
+                        point = new Point(measurement);
+
+                        var fields = msg.payload[0];
+                        addFieldsToPoint(point, fields);
+
+                        const tags = msg.payload[1];
+                        for (const prop in tags) {
+                            point.tag(prop, tags[prop]);
+                        }
+
+                        client.writePoint(point)
+                    }
+                } else {
+                    if (_.isPlainObject(msg.payload)) {
+                        point = new Point(measurement);
+                        var fields = msg.payload;
+                        addFieldsToPoint(point, fields);
+                        client.writePoint(point);
+                    } else {
+                        // just a value
+                        point = new Point(measurement);
+                        var value = msg.payload;
+                        if (typeof value === 'number') {
+                            if (Number.isInteger(value)) {
+                              point.intField('value', value);
+                            } else {
+                              point.floatField('value', value);
+                            }
+                          } else if (typeof value === 'string') {
+                            point.stringField('value', value);
+                          } else if (typeof value === 'boolean') {
+                            point.booleanField('value', value);
+                          }
+                          client.writePoint(point);
+                    }
+                }
+                
+                client
+                    .close()
+                    .catch(error => {
+                        msg.influx_error = {
+                            errorMessage: error
+                        };
+                        node.error(error, msg);
+                    })
+            });
+        } else {
+            this.error(RED._("influxdb2.errors.missingconfig"));
+        }
+    }
+    RED.nodes.registerType("influxdb 2 out",Influx2OutNode);
+    
+    /**
+     * Input node to make queries to InfluxDB 2
+     */
+    function Influx2InNode(n) {
+        RED.nodes.createNode(this, n);
+        this.influxdbConfig = RED.nodes.getNode(n.influxdb);
+        this.org = n.org;
+        this.query = n.query;
+
+        if (this.influxdbConfig) {
+            var node = this;
+            var client = this.influxdbConfig.client;
+
+            node.on("input", function (msg) {                
+                var client = this.influxdbConfig.influxDB.getQueryApi(node.org);                
+                var query = msg.hasOwnProperty('query') ? msg.query : node.query;
+                if (!query) {
+                    node.error(RED._("influxdb2.errors.noquery"), msg);
+                    return;                  
+                }
+                var output = [];
+                client.queryRows(query, {
+                    next(row, tableMeta) {
+                        var o = tableMeta.toObject(row)
+                        output.push(o);
+                    },
+                    error(error) {
+                        msg.influx_error = {
+                            errorMessage: error
+                        };
+                        node.error(error, msg);
+                    },
+                    complete() {
+                        msg.payload = output;
+                        node.send(msg);
+                    },
+                })
+            });
+        } else {
+            this.error(RED._("influxdb2.errors.missingconfig"));
+        }
+    }
+    RED.nodes.registerType("influxdb 2 in",Influx2InNode);
 }

--- a/locales/en-US/influxdb.json
+++ b/locales/en-US/influxdb.json
@@ -12,55 +12,21 @@
             "use-raw-output":"Raw Output",
             "time-precision":"Time Precision",
             "retention-policy":"Retention Policy",
-            "use-advanced-query":"Advanced Query Options"
+            "use-advanced-query":"Advanced Query Options",
+            "version":"Version",
+            "url": "URL",
+            "token": "Token",
+            "org": "Organisation",
+            "bucket": "Bucket"
         },
         "errors":{
             "nomeasurement":"No measurement specified",
             "missingconfig":"Configuration missing"
         },
-        "tip":"<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
-        "querytip":"<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
-    },
-    "influxdb18": {
-        "label": {
-            "url": "URL",
-            "database": "Database",
-            "server": "Server",
-            "measurement": "Measurement",
-            "time-precision": "Precision",
-            "retention-policy": "Retention",
-            "query": "Query"
-        },
         "tip": {
-            "measurement": "<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
-            "retention-policy": "<b> Tip:</b> If no retention policy is specified, <b>autogen</b> will be assumed",
+            "measurement": "<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name.",
+            "retention-policy": "<b> Tip:</b> If no retention policy is specified, <b>autogen</b> will be assumed.",
             "querytip": "<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
-        },
-        "errors":{
-            "nomeasurement": "No measurement specified",
-            "missingconfig": "Configuration missing",
-            "noquery": "No query was especified"
-        }               
-    },
-    "influxdb2": {
-        "label": {
-            "url": "URL",
-            "token": "Token",
-            "server": "Server",
-            "org": "Organisation",
-            "bucket": "Bucket",            
-            "measurement":"Measurement",
-            "time-precision":"Precision",
-            "query":"Query"
-        },
-        "tip": {
-            "measurement": "<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
-            "querytip": "<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
-        },
-        "errors":{            
-            "nomeasurement": "No measurement specified",            
-            "missingconfig": "Configuration missing",
-            "noquery": "No query was especified"
-        }               
+        }
     }
 }

--- a/locales/en-US/influxdb.json
+++ b/locales/en-US/influxdb.json
@@ -20,5 +20,47 @@
         },
         "tip":"<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
         "querytip":"<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
+    },
+    "influxdb18": {
+        "label": {
+            "url": "URL",
+            "database": "Database",
+            "server": "Server",
+            "measurement": "Measurement",
+            "time-precision": "Precision",
+            "retention-policy": "Retention",
+            "query": "Query"
+        },
+        "tip": {
+            "measurement": "<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
+            "retention-policy": "<b> Tip:</b> If no retention policy is specified, <b>autogen</b> will be assumed",
+            "querytip": "<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
+        },
+        "errors":{
+            "nomeasurement": "No measurement specified",
+            "missingconfig": "Configuration missing",
+            "noquery": "No query was especified"
+        }               
+    },
+    "influxdb2": {
+        "label": {
+            "url": "URL",
+            "token": "Token",
+            "server": "Server",
+            "org": "Organisation",
+            "bucket": "Bucket",            
+            "measurement":"Measurement",
+            "time-precision":"Precision",
+            "query":"Query"
+        },
+        "tip": {
+            "measurement": "<b> Tip:</b> If no measurement is specified, ensure <b>msg.measurement</b> contains the measurement name",
+            "querytip": "<b> Tip:</b> If no query is set, ensure <b>msg.query</b> contains a query."
+        },
+        "errors":{            
+            "nomeasurement": "No measurement specified",            
+            "missingconfig": "Configuration missing",
+            "noquery": "No query was especified"
+        }               
     }
 }

--- a/locales/es-ES/influxdb.json
+++ b/locales/es-ES/influxdb.json
@@ -1,0 +1,32 @@
+{
+    "influxdb": {
+        "label": {
+            "host": "Host",
+            "port": "Port",
+            "database": "Database",
+            "measurement":"Medición",
+            "server":"Servidor",
+            "query":"Petición",
+            "use-tls": "Activar conexión (SSL/TLS) segura",
+            "tls-config":"Configuración TLS",
+            "use-raw-output":"Salida en crudo",
+            "time-precision":"Precisión",
+            "retention-policy":"Política de retención",
+            "use-advanced-query":"Opciones avanzadas",
+            "version":"Versión",
+            "url": "URL",
+            "token": "Token",
+            "org": "Organización",
+            "bucket": "Bucket"
+        },
+        "errors":{
+            "nomeasurement":"No se ha especificado una medición",
+            "missingconfig":"Configuración incompleta"
+        },
+        "tip": {
+            "measurement": "<b> TConsejo:</b> Si no se especifica una medición, asegúrate de que <b>msg.measurement</b> contiene el nombre de la medición.",
+            "retention-policy": "<b> Consejo:</b> Si no se especifica una política de retención, se asume <b>autogen</b>.",
+            "querytip": "<b> Consejo:</b> Si no se incluye una petición, asegúrate de que <b>msg.query</b> contiene una."
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,23 @@
 {
   "name": "node-red-contrib-influxdb",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@influxdata/influxdb-client": {
+      "version": "1.5.0",
+      "resolved": "https://artifact.tecnalia.com:443/artifactory/api/npm/digicon-npm-dev/@influxdata/influxdb-client/-/influxdb-client-1.5.0.tgz",
+      "integrity": "sha1-ptEeRBxvw992hb38+nebtHFHptc="
+    },
     "influx": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/influx/-/influx-5.5.2.tgz",
       "integrity": "sha512-N/UxWa/N2rf3fRyBjqlRobtTbIMOBR+yQIoX0Wme3d3qBxgYWfhTVKC7ph6245ZGbLyW1x4OEyKohgP4SddkTA=="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://artifact.tecnalia.com:443/artifactory/api/npm/digicon-npm-dev/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha1-5I3e2+MLMyF4PFtDAfvTU7weSks="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     }
   },
   "dependencies": {
-    "influx": "5.5.2",
-    "@influxdata/influxdb-client": "^1.5.0",
-    "lodash": "4.17.19"
+    "influx": "5.6.3",
+    "@influxdata/influxdb-client": "^1.6.0",
+    "lodash": "4.17.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-influxdb",
-  "version": "0.4.1",
-  "description": "Node-RED nodes to save and query data from an influxdb 1.x time series database",
+  "version": "0.5.0",
+  "description": "Node-RED nodes to save and query data from an influxdb time series database",
   "main": "influxdb.js",
   "scripts": {
     "test": "echo \"Error: no test specified yet!\" && exit 1"
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "influx": "5.5.2",
-    "lodash": "4.17.15"
+    "@influxdata/influxdb-client": "^1.5.0",
+    "lodash": "4.17.19"
   }
 }

--- a/test-flows/.gitignore
+++ b/test-flows/.gitignore
@@ -1,3 +1,2 @@
 influxdb1.8-data/
 influxdb2-data/
-

--- a/test-flows/.gitignore
+++ b/test-flows/.gitignore
@@ -1,0 +1,3 @@
+influxdb1.8-data/
+influxdb2-data/
+

--- a/test-flows/README.md
+++ b/test-flows/README.md
@@ -1,8 +1,8 @@
 # Test Flows README
 
-To test this node, we use influxdb running in a docker container.  Currently testing with influxdb 1.6.3
+To test this node, we use influxdb running in a docker container. Currently tested with InfluxDB 1.8 and 2.0.
 
-Set up influxdb using docker.  See documentation at https://hub.docker.com/_/influxdb/
+Set up influxdb using docker. See documentation at https://hub.docker.com/_/influxdb/
 
 ## Generating influxdb configuration
 
@@ -12,7 +12,7 @@ We have a configuration file already set up for use with a self signed cert.  To
 
 ## Set up self signed certificate
 
-From the [influxdb admim documentation](https://docs.influxdata.com/influxdb/v1.6/administration/https_setup/) you can set up
+From the [influxdb admim documentation](https://docs.influxdata.com/influxdb/v1.8/administration/https_setup/) you can set up
 self signed SSL cert as follows:
 
     sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout ./keys/influxdb-selfsigned.key -out ./keys/influxdb-selfsigned.crt
@@ -21,7 +21,9 @@ Answer the questions as you like.
 
 ## Running influxdb for tests
 
-To run influxdb using the config file in the current directory:
+### Docker
+
+To run influxdb 1.8 using the config file in the current directory:
 
     docker run --name=influxdb -p 8086:8086 \
       -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
@@ -34,8 +36,18 @@ To run the influxdb CLI against this container using a self-signed cert:
 
 You can then execute CLI commands to create databases, make queries, etc..
 
-First, create a `test database to use by the test flows.  
+First, create a `test` database to use by the test flows.  
 
     create database test
 
-Then import the test flows into Node-RED and ensure they work.
+Then, import the test flows into Node-RED and ensure they work.
+
+### Docker Compose
+
+To run InfluxDB 1.8, 2.0 and Chronograf using the config file in the current directory:
+
+    docker-compose up
+
+For InfluxDB 1.8+, select `Unsafe SSL option` in the Connection Configuration section with Chronograf. Create a `test` database to be used by the test flows.
+
+Then, import the test flows into Node-RED and ensure they work.

--- a/test-flows/README.md
+++ b/test-flows/README.md
@@ -1,10 +1,10 @@
 # Test Flows README
 
-To test this node, we use influxdb running in a docker container. Currently tested with InfluxDB 1.8 and 2.0.
+To test this node, we use InfluxDB running in a docker container. Currently tested with InfluxDB 1.8 and 2.0.
 
-Set up influxdb using docker. See documentation at https://hub.docker.com/_/influxdb/
+Set up InfluxDB using docker. See documentation at https://hub.docker.com/_/influxdb/
 
-## Generating influxdb configuration
+## Generating InfluxDB 1.8 configuration
 
 We have a configuration file already set up for use with a self signed cert.  To generate a new, fresh config file locally:
 
@@ -12,29 +12,29 @@ We have a configuration file already set up for use with a self signed cert.  To
 
 ## Set up self signed certificate
 
-From the [influxdb admim documentation](https://docs.influxdata.com/influxdb/v1.8/administration/https_setup/) you can set up
+From the [InfluxDB admim documentation](https://docs.influxdata.com/influxdb/v1.8/administration/https_setup/) you can set up
 self signed SSL cert as follows:
 
     sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout ./keys/influxdb-selfsigned.key -out ./keys/influxdb-selfsigned.crt
 
 Answer the questions as you like.
 
-## Running influxdb for tests
+## Running InfluxDB for tests
 
-### Docker
+### Docker Method
 
-To run influxdb 1.8 using the config file in the current directory:
+To run InfluxDB 1.8 using the config file in the current directory:
 
     docker run --name=influxdb -p 8086:8086 \
       -v $PWD/influxdb.conf:/etc/influxdb/influxdb.conf:ro \
       -v $PWD/ssl:/etc/ssl \
       influxdb:1.8 -config /etc/influxdb/influxdb.conf
 
-To run the influxdb CLI against this container using a self-signed cert:
+To run the InfluxDB CLI against this container using a self-signed cert:
 
     docker run --rm --link=influxdb -it influxdb influx -ssl -unsafeSsl -host influxdb
 
-You can then execute CLI commands to create databases, make queries, etc..
+You can then execute CLI commands to create databases, make queries, etc.
 
 First, create a `test` database to use by the test flows.  
 
@@ -42,12 +42,51 @@ First, create a `test` database to use by the test flows.
 
 Then, import the test flows into Node-RED and ensure they work.
 
-### Docker Compose
+### Docker Compose Method
 
 To run InfluxDB 1.8, 2.0 and Chronograf using the config file in the current directory:
 
     docker-compose up
 
-For InfluxDB 1.8+, select `Unsafe SSL option` in the Connection Configuration section with Chronograf. Create a `test` database to be used by the test flows.
-
 Then, import the test flows into Node-RED and ensure they work.
+
+1 - Launch Chronograf for InfluxDB 1.8 and 1.8 Flux: https://localhost:8888/
+
+* Select `Unsafe SSL option` in the Connection Configuration section with Chronograf. Create a `test` database to be used by the test flows.
+* Test flows parameters: 
+    * Database: test
+    * Measurement: test
+    * Precision: ms
+    * Credentials:
+        * Username: username
+        * Password: password
+    
+2 - Launch Chronograf for InfluxDB 2.0: https://localhost:9999
+
+* Test flows parameters:
+    * Bucket: test
+    * Measurement: test
+    * Precision: ms
+    * Organisation: my-org
+    * Credentials:
+        * Username: my-user
+        * Password: my-password
+        * Token: Create one under `Load Data/Tokens`
+
+#### Select Test Query:
+* InfluxDB 1.8
+    
+        SELECT * FROM "test"."autogen"."test"
+
+#### Flux Test Query:
+* InfluxDB 1.8 Flux
+
+        from(bucket: "test/autogen")
+          |> range(start: -1m, stop: 1h)
+          |> filter(fn: (r) => r._measurement == "test")
+
+* InfluxDB 2.0
+
+        from(bucket: "test")
+          |> range(start: -1m, stop: 1h)
+          |> filter(fn: (r) => r._measurement == "test")

--- a/test-flows/docker-compose.yml
+++ b/test-flows/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.3'
+services:
+  # Define an InfluxDB v1.8 service
+  influxdb:
+    image: 'influxdb:1.8'
+    container_name: influxdb
+    ports:
+      - '8086:8086'
+    volumes:
+      - './influxdb1.8-data/influxdb:/var/lib/influxdb'
+      - './influxdb.conf:/etc/influxdb/influxdb.conf:ro'
+      - './ssl:/etc/ssl'
+
+  # Define a Chronograf service
+  chronograf:
+    image: chronograf:1.8
+    container_name: chronograf
+    environment:
+      INFLUXDB_URL: https://influxdb:8086
+      TLS_CERTIFICATE: '/etc/ssl/influxdb-selfsigned.crt'
+      TLS_PRIVATE_KEY: '/etc/ssl/influxdb-selfsigned.key'
+    volumes:
+      - './ssl:/etc/ssl'      
+    ports:
+      - "8888:8888"
+    depends_on:
+      - influxdb
+
+  # Define an InfluxDB v2 service
+  influxdb2:
+    container_name: influxdb2
+    ports:
+      - '9999:9999'
+    image: 'quay.io/influxdb/influxdb:2.0.0-alpha'
+    volumes:
+      - './influxdb2-data:/var/lib/influxdb2'
+      - './ssl:/etc/ssl'
+    command: influxd run --bolt-path /var/lib/influxdb2/influxd.bolt --engine-path /var/lib/influxdb2/engine --store bolt --tls-cert /etc/ssl/influxdb-selfsigned.crt --tls-key /etc/ssl/influxdb-selfsigned.key
+    depends_on:
+      - chronograf

--- a/test-flows/influxdb.conf
+++ b/test-flows/influxdb.conf
@@ -78,6 +78,7 @@ bind-address = "127.0.0.1:8088"
   max-concurrent-write-limit = 0
   max-enqueued-write-limit = 0
   enqueued-write-timeout = 30000000000
+  flux-enabled = true
 
 [logging]
   format = "auto"

--- a/test-flows/test-flows.json
+++ b/test-flows/test-flows.json
@@ -1,249 +1,27 @@
 [
     {
-        "id": "99bf88cf.4254c8",
-        "type": "influxdb in",
-        "z": "e7ce51cb.4244",
-        "influxdb": "730dac77.69ca34",
-        "name": "",
-        "query": "select * from test",
-        "rawOutput": false,
-        "precision": "",
-        "retentionPolicy": "",
-        "x": 450,
-        "y": 400,
-        "wires": [
-            [
-                "fa349e8c.f740a"
-            ]
-        ]
+        "id": "675bec0c.46dbd4",
+        "type": "tab",
+        "label": "InfluxDB 1.8",
+        "disabled": false,
+        "info": ""
     },
     {
-        "id": "d1adae5b.bca4",
-        "type": "inject",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "x": 200,
-        "y": 400,
-        "wires": [
-            [
-                "99bf88cf.4254c8"
-            ]
-        ]
+        "id": "653805bf.2d2784",
+        "type": "tab",
+        "label": "InfluxDB 1.8 flux",
+        "disabled": false,
+        "info": ""
     },
     {
-        "id": "fa349e8c.f740a",
-        "type": "debug",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "x": 710,
-        "y": 400,
-        "wires": []
+        "id": "c70ec85f.ffbc3",
+        "type": "tab",
+        "label": "InfluxDB 2",
+        "disabled": false,
+        "info": ""
     },
     {
-        "id": "eac189ce.f28be8",
-        "type": "inject",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "x": 360,
-        "y": 100,
-        "wires": [
-            [
-                "b397e971.522bd8"
-            ]
-        ]
-    },
-    {
-        "id": "b397e971.522bd8",
-        "type": "function",
-        "z": "e7ce51cb.4244",
-        "name": "Fields",
-        "func": "msg.payload = {\n    numValue: 123.0,\n    strValue: \"message\",\n    randomValue: Math.random()*10\n}\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 508,
-        "y": 100,
-        "wires": [
-            [
-                "51fc70d6.dc65b"
-            ]
-        ]
-    },
-    {
-        "id": "51fc70d6.dc65b",
-        "type": "influxdb out",
-        "z": "e7ce51cb.4244",
-        "influxdb": "730dac77.69ca34",
-        "name": "",
-        "measurement": "test",
-        "precision": "",
-        "retentionPolicy": "",
-        "x": 698,
-        "y": 100,
-        "wires": []
-    },
-    {
-        "id": "a9d0f3cc.bbceb",
-        "type": "inject",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "x": 340,
-        "y": 160,
-        "wires": [
-            [
-                "a284e9c0.969b08"
-            ]
-        ]
-    },
-    {
-        "id": "a284e9c0.969b08",
-        "type": "function",
-        "z": "e7ce51cb.4244",
-        "name": "Fields and Tags",
-        "func": "msg.payload = [{\n    numValue: 12,\n    randomValue: Math.random()*10,\n    strValue: \"message2\"\n},\n{\n    tag1:\"sensor1\",\n    tag2:\"device2\"\n}];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 511,
-        "y": 160,
-        "wires": [
-            [
-                "2056b637.2cdf8a"
-            ]
-        ]
-    },
-    {
-        "id": "2056b637.2cdf8a",
-        "type": "influxdb out",
-        "z": "e7ce51cb.4244",
-        "influxdb": "730dac77.69ca34",
-        "name": "",
-        "measurement": "test",
-        "precision": "",
-        "retentionPolicy": "",
-        "x": 719,
-        "y": 160,
-        "wires": []
-    },
-    {
-        "id": "b70228ff.b5c1c8",
-        "type": "function",
-        "z": "e7ce51cb.4244",
-        "name": "multiple readings",
-        "func": "msg.payload = [\n    [{\n        numValue: 10,\n        randomValue: Math.random()*10,\n        strValue: \"message1\",\n        time: new Date(\"2015-12-28T19:41:13Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }],\n    [{\n        numValue: 20,\n        randomValue: Math.random()*10,\n        strValue: \"message2\",\n        time: new Date(\"2015-12-28T19:41:14Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }]\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 490,
-        "y": 240,
-        "wires": [
-            [
-                "f77ae03a.c8af"
-            ]
-        ]
-    },
-    {
-        "id": "cc5a4f6c.7ca5",
-        "type": "inject",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "x": 316,
-        "y": 240,
-        "wires": [
-            [
-                "b70228ff.b5c1c8"
-            ]
-        ]
-    },
-    {
-        "id": "f77ae03a.c8af",
-        "type": "influxdb out",
-        "z": "e7ce51cb.4244",
-        "influxdb": "730dac77.69ca34",
-        "name": "",
-        "measurement": "test",
-        "precision": "",
-        "retentionPolicy": "",
-        "x": 711,
-        "y": 239,
-        "wires": []
-    },
-    {
-        "id": "b005e63a.2cde38",
-        "type": "function",
-        "z": "e7ce51cb.4244",
-        "name": "multiple measurement points",
-        "func": "msg.payload = [\n    {\n        measurement: \"weather_sensor\",\n        fields: {\n            temp: 5.5,\n            light: 678,\n            humidity: 51\n        },\n        tags:{\n            location:\"garden\"\n        },\n        timestamp: new Date()\n    },\n    {\n        measurement: \"alarm_sensor\",\n        fields: {\n            proximity: 999,\n            temp: 19.5\n        },\n        tags:{\n            location:\"home\"\n        },\n        timestamp: new Date()\n    }\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 440,
-        "y": 320,
-        "wires": [
-            [
-                "ea1abed6.da87d"
-            ]
-        ]
-    },
-    {
-        "id": "fb899d8a.42d35",
-        "type": "inject",
-        "z": "e7ce51cb.4244",
-        "name": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "x": 220,
-        "y": 320,
-        "wires": [
-            [
-                "b005e63a.2cde38"
-            ]
-        ]
-    },
-    {
-        "id": "ea1abed6.da87d",
-        "type": "influxdb batch",
-        "z": "e7ce51cb.4244",
-        "influxdb": "730dac77.69ca34",
-        "precision": "",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 690,
-        "y": 320,
-        "wires": []
-    },
-    {
-        "id": "730dac77.69ca34",
+        "id": "df96ca87.d13428",
         "type": "influxdb",
         "z": "",
         "hostname": "127.0.0.1",
@@ -252,20 +30,890 @@
         "database": "test",
         "name": "",
         "usetls": true,
-        "tls": "8086d718.bcda28"
+        "tls": "d50d0c9f.31e858"
     },
     {
-        "id": "8086d718.bcda28",
+        "id": "d50d0c9f.31e858",
         "type": "tls-config",
         "z": "",
         "name": "",
         "cert": "",
         "key": "",
         "ca": "",
-        "certname": "",
-        "keyname": "",
+        "certname": "influxdb-selfsigned.crt",
+        "keyname": "influxdb-selfsigned.key",
         "caname": "",
         "servername": "",
         "verifyservercert": false
+    },
+    {
+        "id": "eb34baa.56944c8",
+        "type": "influxdb18flux",
+        "z": "",
+        "url": "https://localhost:8086",
+        "name": ""
+    },
+    {
+        "id": "3dcd3c8e.fe9b24",
+        "type": "influxdb2",
+        "z": "",
+        "url": "https://localhost:9999",
+        "token": "M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==",
+        "name": ""
+    },
+    {
+        "id": "c2ea71f2.6e7ee8",
+        "type": "influxdb in",
+        "z": "675bec0c.46dbd4",
+        "influxdb": "df96ca87.d13428",
+        "name": "",
+        "query": "SELECT * from test",
+        "rawOutput": false,
+        "precision": "",
+        "retentionPolicy": "",
+        "x": 420,
+        "y": 340,
+        "wires": [
+            [
+                "4eb1c830.f46c18"
+            ]
+        ]
+    },
+    {
+        "id": "1c929879.20ea78",
+        "type": "inject",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 160,
+        "y": 340,
+        "wires": [
+            [
+                "c2ea71f2.6e7ee8"
+            ]
+        ]
+    },
+    {
+        "id": "4eb1c830.f46c18",
+        "type": "debug",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "x": 690,
+        "y": 340,
+        "wires": []
+    },
+    {
+        "id": "74d2118d.6dc7b8",
+        "type": "inject",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 320,
+        "y": 40,
+        "wires": [
+            [
+                "1d651a65.b7e6ee"
+            ]
+        ]
+    },
+    {
+        "id": "1d651a65.b7e6ee",
+        "type": "function",
+        "z": "675bec0c.46dbd4",
+        "name": "Fields",
+        "func": "msg.payload = {\n    numValue: 123.0,\n    strValue: \"message\",\n    randomValue: Math.random()*10\n}\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "x": 468,
+        "y": 40,
+        "wires": [
+            [
+                "63ba3d84.7c2dac"
+            ]
+        ]
+    },
+    {
+        "id": "63ba3d84.7c2dac",
+        "type": "influxdb out",
+        "z": "675bec0c.46dbd4",
+        "influxdb": "df96ca87.d13428",
+        "name": "",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "x": 670,
+        "y": 40,
+        "wires": []
+    },
+    {
+        "id": "d4ab44e3.058ac",
+        "type": "inject",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 300,
+        "y": 100,
+        "wires": [
+            [
+                "b152581e.9c1b2"
+            ]
+        ]
+    },
+    {
+        "id": "b152581e.9c1b2",
+        "type": "function",
+        "z": "675bec0c.46dbd4",
+        "name": "Fields and Tags",
+        "func": "msg.payload = [{\n    numValue: 12,\n    randomValue: Math.random()*10,\n    strValue: \"message2\"\n},\n{\n    tag1:\"sensor1\",\n    tag2:\"device2\"\n}];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 471,
+        "y": 100,
+        "wires": [
+            [
+                "4e0835ac.406c44"
+            ]
+        ]
+    },
+    {
+        "id": "4e0835ac.406c44",
+        "type": "influxdb out",
+        "z": "675bec0c.46dbd4",
+        "influxdb": "df96ca87.d13428",
+        "name": "",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "x": 679,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "abc53c6e.db7e38",
+        "type": "function",
+        "z": "675bec0c.46dbd4",
+        "name": "multiple readings",
+        "func": "msg.payload = [\n    [{\n        numValue: 10,\n        randomValue: Math.random()*10,\n        strValue: \"message1\",\n        time: new Date(\"2015-12-28T19:41:13Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }],\n    [{\n        numValue: 20,\n        randomValue: Math.random()*10,\n        strValue: \"message2\",\n        time: new Date(\"2015-12-28T19:41:14Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }]\n];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 450,
+        "y": 180,
+        "wires": [
+            [
+                "833789c9.586a"
+            ]
+        ]
+    },
+    {
+        "id": "76c0a613.0913c",
+        "type": "inject",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 276,
+        "y": 180,
+        "wires": [
+            [
+                "abc53c6e.db7e38"
+            ]
+        ]
+    },
+    {
+        "id": "833789c9.586a",
+        "type": "influxdb out",
+        "z": "675bec0c.46dbd4",
+        "influxdb": "df96ca87.d13428",
+        "name": "",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "x": 671,
+        "y": 179,
+        "wires": []
+    },
+    {
+        "id": "d24946a8.e84d2",
+        "type": "function",
+        "z": "675bec0c.46dbd4",
+        "name": "multiple measurement points",
+        "func": "msg.payload = [\n    {\n        measurement: \"weather_sensor\",\n        fields: {\n            temp: 5.5,\n            light: 678,\n            humidity: 51\n        },\n        tags:{\n            location:\"garden\"\n        },\n        timestamp: new Date()\n    },\n    {\n        measurement: \"alarm_sensor\",\n        fields: {\n            proximity: 999,\n            temp: 19.5\n        },\n        tags:{\n            location:\"home\"\n        },\n        timestamp: new Date()\n    }\n];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "x": 400,
+        "y": 260,
+        "wires": [
+            [
+                "d6516113.48e038"
+            ]
+        ]
+    },
+    {
+        "id": "53c37662.0e30e8",
+        "type": "inject",
+        "z": "675bec0c.46dbd4",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 180,
+        "y": 260,
+        "wires": [
+            [
+                "d24946a8.e84d2"
+            ]
+        ]
+    },
+    {
+        "id": "d6516113.48e038",
+        "type": "influxdb batch",
+        "z": "675bec0c.46dbd4",
+        "influxdb": "df96ca87.d13428",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "name": "",
+        "x": 650,
+        "y": 260,
+        "wires": []
+    },
+    {
+        "id": "4fc65aec.2d88bc",
+        "type": "inject",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 120,
+        "wires": [
+            [
+                "b6d751d.392793"
+            ]
+        ]
+    },
+    {
+        "id": "b6d751d.392793",
+        "type": "function",
+        "z": "653805bf.2d2784",
+        "name": "Fields",
+        "func": "msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 310,
+        "y": 120,
+        "wires": [
+            [
+                "207a1809.718b5"
+            ]
+        ]
+    },
+    {
+        "id": "69e12add.55122c",
+        "type": "catch",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "scope": [
+            "61db7932.0bc2b8"
+        ],
+        "uncaught": false,
+        "x": 110,
+        "y": 380,
+        "wires": [
+            [
+                "eb70b7f.ef181c8"
+            ]
+        ]
+    },
+    {
+        "id": "eb70b7f.ef181c8",
+        "type": "debug",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 300,
+        "y": 380,
+        "wires": []
+    },
+    {
+        "id": "207a1809.718b5",
+        "type": "influxdb 1.8 flux out",
+        "z": "653805bf.2d2784",
+        "influxdb": "eb34baa.56944c8",
+        "database": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "name": "",
+        "x": 580,
+        "y": 120,
+        "wires": []
+    },
+    {
+        "id": "120c5823.db609",
+        "type": "inject",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "props": [
+            {
+                "p": "payload",
+                "v": "",
+                "vt": "date"
+            },
+            {
+                "p": "topic",
+                "v": "",
+                "vt": "string"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 60,
+        "wires": [
+            [
+                "eb30f561.c70148"
+            ]
+        ]
+    },
+    {
+        "id": "eb30f561.c70148",
+        "type": "function",
+        "z": "653805bf.2d2784",
+        "name": "Single Value",
+        "func": "msg.payload = Math.random() * 10;\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 330,
+        "y": 60,
+        "wires": [
+            [
+                "cad9f0d2.1463e8"
+            ]
+        ]
+    },
+    {
+        "id": "cad9f0d2.1463e8",
+        "type": "influxdb 1.8 flux out",
+        "z": "653805bf.2d2784",
+        "influxdb": "eb34baa.56944c8",
+        "database": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "name": "",
+        "x": 580,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "e33df9a0.62473",
+        "type": "inject",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 180,
+        "wires": [
+            [
+                "d195b182.a4702"
+            ]
+        ]
+    },
+    {
+        "id": "d195b182.a4702",
+        "type": "function",
+        "z": "653805bf.2d2784",
+        "name": "Fields and Tags",
+        "func": "msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 340,
+        "y": 180,
+        "wires": [
+            [
+                "bf4607a5.cc9a88"
+            ]
+        ]
+    },
+    {
+        "id": "bf4607a5.cc9a88",
+        "type": "influxdb 1.8 flux out",
+        "z": "653805bf.2d2784",
+        "influxdb": "eb34baa.56944c8",
+        "database": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "name": "",
+        "x": 610,
+        "y": 180,
+        "wires": []
+    },
+    {
+        "id": "99251519.a7b3e8",
+        "type": "inject",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 240,
+        "wires": [
+            [
+                "1bf3451b.36b1bb"
+            ]
+        ]
+    },
+    {
+        "id": "1bf3451b.36b1bb",
+        "type": "function",
+        "z": "653805bf.2d2784",
+        "name": "multiple readings",
+        "func": "msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 350,
+        "y": 240,
+        "wires": [
+            [
+                "fd4b0034.d7eb7"
+            ]
+        ]
+    },
+    {
+        "id": "fd4b0034.d7eb7",
+        "type": "influxdb 1.8 flux out",
+        "z": "653805bf.2d2784",
+        "influxdb": "eb34baa.56944c8",
+        "database": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "retentionPolicy": "",
+        "name": "",
+        "x": 610,
+        "y": 240,
+        "wires": []
+    },
+    {
+        "id": "2c24bff8.5d5fb",
+        "type": "influxdb 1.8 flux in",
+        "z": "653805bf.2d2784",
+        "influxdb": "eb34baa.56944c8",
+        "query": "from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)",
+        "name": "",
+        "x": 520,
+        "y": 300,
+        "wires": [
+            [
+                "9ec53e18.774c18"
+            ]
+        ]
+    },
+    {
+        "id": "9ec53e18.774c18",
+        "type": "debug",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "x": 930,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "a89497f8.4c509",
+        "type": "inject",
+        "z": "653805bf.2d2784",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 300,
+        "wires": [
+            [
+                "2c24bff8.5d5fb"
+            ]
+        ]
+    },
+    {
+        "id": "1606c311.639f3d",
+        "type": "inject",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 120,
+        "wires": [
+            [
+                "6fad44a5.d5f544"
+            ]
+        ]
+    },
+    {
+        "id": "6fad44a5.d5f544",
+        "type": "function",
+        "z": "c70ec85f.ffbc3",
+        "name": "Fields",
+        "func": "msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 310,
+        "y": 120,
+        "wires": [
+            [
+                "a57b64be.670488"
+            ]
+        ]
+    },
+    {
+        "id": "d390a898.f747a",
+        "type": "catch",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "scope": [
+            "61db7932.0bc2b8"
+        ],
+        "uncaught": false,
+        "x": 110,
+        "y": 380,
+        "wires": [
+            [
+                "2fb394b6.0d2684"
+            ]
+        ]
+    },
+    {
+        "id": "2fb394b6.0d2684",
+        "type": "debug",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 300,
+        "y": 380,
+        "wires": []
+    },
+    {
+        "id": "d9f0ebfc.ecfec8",
+        "type": "inject",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "props": [
+            {
+                "p": "payload",
+                "v": "",
+                "vt": "date"
+            },
+            {
+                "p": "topic",
+                "v": "",
+                "vt": "string"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 60,
+        "wires": [
+            [
+                "c555c3a0.204c58"
+            ]
+        ]
+    },
+    {
+        "id": "c555c3a0.204c58",
+        "type": "function",
+        "z": "c70ec85f.ffbc3",
+        "name": "Single Value",
+        "func": "msg.payload = Math.random() * 10;\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 330,
+        "y": 60,
+        "wires": [
+            [
+                "f5a4befd.56d75"
+            ]
+        ]
+    },
+    {
+        "id": "f35e5815.9ac48",
+        "type": "inject",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 180,
+        "wires": [
+            [
+                "cc6a2a67.5edc28"
+            ]
+        ]
+    },
+    {
+        "id": "cc6a2a67.5edc28",
+        "type": "function",
+        "z": "c70ec85f.ffbc3",
+        "name": "Fields and Tags",
+        "func": "msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 340,
+        "y": 180,
+        "wires": [
+            [
+                "42816c54.99f794"
+            ]
+        ]
+    },
+    {
+        "id": "cab64da3.ec089",
+        "type": "inject",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "",
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 240,
+        "wires": [
+            [
+                "45dc1b5a.7ab1d4"
+            ]
+        ]
+    },
+    {
+        "id": "45dc1b5a.7ab1d4",
+        "type": "function",
+        "z": "c70ec85f.ffbc3",
+        "name": "multiple readings",
+        "func": "msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 350,
+        "y": 240,
+        "wires": [
+            [
+                "3c9f8227.c549de"
+            ]
+        ]
+    },
+    {
+        "id": "3e760db.d141d72",
+        "type": "debug",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "x": 930,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "6d054c00.b726dc",
+        "type": "inject",
+        "z": "c70ec85f.ffbc3",
+        "name": "",
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 300,
+        "wires": [
+            [
+                "de82c653.cd498"
+            ]
+        ]
+    },
+    {
+        "id": "f5a4befd.56d75",
+        "type": "influxdb 2 out",
+        "z": "c70ec85f.ffbc3",
+        "influxdb": "3dcd3c8e.fe9b24",
+        "org": "my-org",
+        "bucket": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "name": "",
+        "x": 650,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "a57b64be.670488",
+        "type": "influxdb 2 out",
+        "z": "c70ec85f.ffbc3",
+        "influxdb": "3dcd3c8e.fe9b24",
+        "org": "my-org",
+        "bucket": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "name": "",
+        "x": 650,
+        "y": 120,
+        "wires": []
+    },
+    {
+        "id": "42816c54.99f794",
+        "type": "influxdb 2 out",
+        "z": "c70ec85f.ffbc3",
+        "influxdb": "3dcd3c8e.fe9b24",
+        "org": "my-org",
+        "bucket": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "name": "",
+        "x": 650,
+        "y": 180,
+        "wires": []
+    },
+    {
+        "id": "3c9f8227.c549de",
+        "type": "influxdb 2 out",
+        "z": "c70ec85f.ffbc3",
+        "influxdb": "3dcd3c8e.fe9b24",
+        "org": "my-org",
+        "bucket": "test",
+        "measurement": "test",
+        "precision": "ms",
+        "name": "",
+        "x": 650,
+        "y": 240,
+        "wires": []
+    },
+    {
+        "id": "de82c653.cd498",
+        "type": "influxdb 2 in",
+        "z": "c70ec85f.ffbc3",
+        "influxdb": "3dcd3c8e.fe9b24",
+        "org": "my-org",
+        "query": "from(bucket: \"test\") |> range(start: -1m, stop: 1h)",
+        "name": "",
+        "x": 500,
+        "y": 300,
+        "wires": [
+            [
+                "3e760db.d141d72"
+            ]
+        ]
     }
 ]

--- a/test-flows/test-flows.json
+++ b/test-flows/test-flows.json
@@ -1,919 +1,559 @@
 [
-    {
-        "id": "675bec0c.46dbd4",
-        "type": "tab",
-        "label": "InfluxDB 1.8",
-        "disabled": false,
-        "info": ""
-    },
-    {
-        "id": "653805bf.2d2784",
-        "type": "tab",
-        "label": "InfluxDB 1.8 flux",
-        "disabled": false,
-        "info": ""
-    },
-    {
-        "id": "c70ec85f.ffbc3",
-        "type": "tab",
-        "label": "InfluxDB 2",
-        "disabled": false,
-        "info": ""
-    },
-    {
-        "id": "df96ca87.d13428",
-        "type": "influxdb",
-        "z": "",
-        "hostname": "127.0.0.1",
-        "port": "8086",
-        "protocol": "http",
-        "database": "test",
-        "name": "",
-        "usetls": true,
-        "tls": "d50d0c9f.31e858"
-    },
-    {
-        "id": "d50d0c9f.31e858",
-        "type": "tls-config",
-        "z": "",
-        "name": "",
-        "cert": "",
-        "key": "",
-        "ca": "",
-        "certname": "influxdb-selfsigned.crt",
-        "keyname": "influxdb-selfsigned.key",
-        "caname": "",
-        "servername": "",
-        "verifyservercert": false
-    },
-    {
-        "id": "eb34baa.56944c8",
-        "type": "influxdb18flux",
-        "z": "",
-        "url": "https://localhost:8086",
-        "name": ""
-    },
-    {
-        "id": "3dcd3c8e.fe9b24",
-        "type": "influxdb2",
-        "z": "",
-        "url": "https://localhost:9999",
-        "token": "M7r8bFX-PqZVyehdeKKRqnGiGq8HIKkSSgcKJulra63_FrJydTtm_KmzTm_KzZLuME69xBCTW-MFbOBl2JpGtg==",
-        "name": ""
-    },
-    {
-        "id": "c2ea71f2.6e7ee8",
-        "type": "influxdb in",
-        "z": "675bec0c.46dbd4",
-        "influxdb": "df96ca87.d13428",
-        "name": "",
-        "query": "SELECT * from test",
-        "rawOutput": false,
-        "precision": "",
-        "retentionPolicy": "",
-        "x": 420,
-        "y": 340,
-        "wires": [
-            [
-                "4eb1c830.f46c18"
-            ]
-        ]
-    },
-    {
-        "id": "1c929879.20ea78",
-        "type": "inject",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 160,
-        "y": 340,
-        "wires": [
-            [
-                "c2ea71f2.6e7ee8"
-            ]
-        ]
-    },
-    {
-        "id": "4eb1c830.f46c18",
-        "type": "debug",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "x": 690,
-        "y": 340,
-        "wires": []
-    },
-    {
-        "id": "74d2118d.6dc7b8",
-        "type": "inject",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 320,
-        "y": 40,
-        "wires": [
-            [
-                "1d651a65.b7e6ee"
-            ]
-        ]
-    },
-    {
-        "id": "1d651a65.b7e6ee",
-        "type": "function",
-        "z": "675bec0c.46dbd4",
-        "name": "Fields",
-        "func": "msg.payload = {\n    numValue: 123.0,\n    strValue: \"message\",\n    randomValue: Math.random()*10\n}\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 468,
-        "y": 40,
-        "wires": [
-            [
-                "63ba3d84.7c2dac"
-            ]
-        ]
-    },
-    {
-        "id": "63ba3d84.7c2dac",
-        "type": "influxdb out",
-        "z": "675bec0c.46dbd4",
-        "influxdb": "df96ca87.d13428",
-        "name": "",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "x": 670,
-        "y": 40,
-        "wires": []
-    },
-    {
-        "id": "d4ab44e3.058ac",
-        "type": "inject",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 300,
-        "y": 100,
-        "wires": [
-            [
-                "b152581e.9c1b2"
-            ]
-        ]
-    },
-    {
-        "id": "b152581e.9c1b2",
-        "type": "function",
-        "z": "675bec0c.46dbd4",
-        "name": "Fields and Tags",
-        "func": "msg.payload = [{\n    numValue: 12,\n    randomValue: Math.random()*10,\n    strValue: \"message2\"\n},\n{\n    tag1:\"sensor1\",\n    tag2:\"device2\"\n}];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 471,
-        "y": 100,
-        "wires": [
-            [
-                "4e0835ac.406c44"
-            ]
-        ]
-    },
-    {
-        "id": "4e0835ac.406c44",
-        "type": "influxdb out",
-        "z": "675bec0c.46dbd4",
-        "influxdb": "df96ca87.d13428",
-        "name": "",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "x": 679,
-        "y": 100,
-        "wires": []
-    },
-    {
-        "id": "abc53c6e.db7e38",
-        "type": "function",
-        "z": "675bec0c.46dbd4",
-        "name": "multiple readings",
-        "func": "msg.payload = [\n    [{\n        numValue: 10,\n        randomValue: Math.random()*10,\n        strValue: \"message1\",\n        time: new Date(\"2015-12-28T19:41:13Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }],\n    [{\n        numValue: 20,\n        randomValue: Math.random()*10,\n        strValue: \"message2\",\n        time: new Date(\"2015-12-28T19:41:14Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }]\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 450,
-        "y": 180,
-        "wires": [
-            [
-                "833789c9.586a"
-            ]
-        ]
-    },
-    {
-        "id": "76c0a613.0913c",
-        "type": "inject",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 276,
-        "y": 180,
-        "wires": [
-            [
-                "abc53c6e.db7e38"
-            ]
-        ]
-    },
-    {
-        "id": "833789c9.586a",
-        "type": "influxdb out",
-        "z": "675bec0c.46dbd4",
-        "influxdb": "df96ca87.d13428",
-        "name": "",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "x": 671,
-        "y": 179,
-        "wires": []
-    },
-    {
-        "id": "d24946a8.e84d2",
-        "type": "function",
-        "z": "675bec0c.46dbd4",
-        "name": "multiple measurement points",
-        "func": "msg.payload = [\n    {\n        measurement: \"weather_sensor\",\n        fields: {\n            temp: 5.5,\n            light: 678,\n            humidity: 51\n        },\n        tags:{\n            location:\"garden\"\n        },\n        timestamp: new Date()\n    },\n    {\n        measurement: \"alarm_sensor\",\n        fields: {\n            proximity: 999,\n            temp: 19.5\n        },\n        tags:{\n            location:\"home\"\n        },\n        timestamp: new Date()\n    }\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 400,
-        "y": 260,
-        "wires": [
-            [
-                "d6516113.48e038"
-            ]
-        ]
-    },
-    {
-        "id": "53c37662.0e30e8",
-        "type": "inject",
-        "z": "675bec0c.46dbd4",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 180,
-        "y": 260,
-        "wires": [
-            [
-                "d24946a8.e84d2"
-            ]
-        ]
-    },
-    {
-        "id": "d6516113.48e038",
-        "type": "influxdb batch",
-        "z": "675bec0c.46dbd4",
-        "influxdb": "df96ca87.d13428",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 650,
-        "y": 260,
-        "wires": []
-    },
-    {
-        "id": "4fc65aec.2d88bc",
-        "type": "inject",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 120,
-        "wires": [
-            [
-                "b6d751d.392793"
-            ]
-        ]
-    },
-    {
-        "id": "b6d751d.392793",
-        "type": "function",
-        "z": "653805bf.2d2784",
-        "name": "Fields",
-        "func": "msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 310,
-        "y": 120,
-        "wires": [
-            [
-                "207a1809.718b5"
-            ]
-        ]
-    },
-    {
-        "id": "69e12add.55122c",
-        "type": "catch",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "scope": [
-            "61db7932.0bc2b8"
-        ],
-        "uncaught": false,
-        "x": 110,
-        "y": 380,
-        "wires": [
-            [
-                "eb70b7f.ef181c8"
-            ]
-        ]
-    },
-    {
-        "id": "eb70b7f.ef181c8",
-        "type": "debug",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 300,
-        "y": 380,
-        "wires": []
-    },
-    {
-        "id": "207a1809.718b5",
-        "type": "influxdb 1.8 flux out",
-        "z": "653805bf.2d2784",
-        "influxdb": "eb34baa.56944c8",
-        "database": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 580,
-        "y": 120,
-        "wires": []
-    },
-    {
-        "id": "120c5823.db609",
-        "type": "inject",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "props": [
-            {
-                "p": "payload",
-                "v": "",
-                "vt": "date"
-            },
-            {
-                "p": "topic",
-                "v": "",
-                "vt": "string"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 60,
-        "wires": [
-            [
-                "eb30f561.c70148"
-            ]
-        ]
-    },
-    {
-        "id": "eb30f561.c70148",
-        "type": "function",
-        "z": "653805bf.2d2784",
-        "name": "Single Value",
-        "func": "msg.payload = Math.random() * 10;\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 330,
-        "y": 60,
-        "wires": [
-            [
-                "cad9f0d2.1463e8"
-            ]
-        ]
-    },
-    {
-        "id": "cad9f0d2.1463e8",
-        "type": "influxdb 1.8 flux out",
-        "z": "653805bf.2d2784",
-        "influxdb": "eb34baa.56944c8",
-        "database": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 580,
-        "y": 60,
-        "wires": []
-    },
-    {
-        "id": "e33df9a0.62473",
-        "type": "inject",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 180,
-        "wires": [
-            [
-                "d195b182.a4702"
-            ]
-        ]
-    },
-    {
-        "id": "d195b182.a4702",
-        "type": "function",
-        "z": "653805bf.2d2784",
-        "name": "Fields and Tags",
-        "func": "msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 340,
-        "y": 180,
-        "wires": [
-            [
-                "bf4607a5.cc9a88"
-            ]
-        ]
-    },
-    {
-        "id": "bf4607a5.cc9a88",
-        "type": "influxdb 1.8 flux out",
-        "z": "653805bf.2d2784",
-        "influxdb": "eb34baa.56944c8",
-        "database": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 610,
-        "y": 180,
-        "wires": []
-    },
-    {
-        "id": "99251519.a7b3e8",
-        "type": "inject",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 240,
-        "wires": [
-            [
-                "1bf3451b.36b1bb"
-            ]
-        ]
-    },
-    {
-        "id": "1bf3451b.36b1bb",
-        "type": "function",
-        "z": "653805bf.2d2784",
-        "name": "multiple readings",
-        "func": "msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 350,
-        "y": 240,
-        "wires": [
-            [
-                "fd4b0034.d7eb7"
-            ]
-        ]
-    },
-    {
-        "id": "fd4b0034.d7eb7",
-        "type": "influxdb 1.8 flux out",
-        "z": "653805bf.2d2784",
-        "influxdb": "eb34baa.56944c8",
-        "database": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "retentionPolicy": "",
-        "name": "",
-        "x": 610,
-        "y": 240,
-        "wires": []
-    },
-    {
-        "id": "2c24bff8.5d5fb",
-        "type": "influxdb 1.8 flux in",
-        "z": "653805bf.2d2784",
-        "influxdb": "eb34baa.56944c8",
-        "query": "from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)",
-        "name": "",
-        "x": 520,
-        "y": 300,
-        "wires": [
-            [
-                "9ec53e18.774c18"
-            ]
-        ]
-    },
-    {
-        "id": "9ec53e18.774c18",
-        "type": "debug",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "x": 930,
-        "y": 300,
-        "wires": []
-    },
-    {
-        "id": "a89497f8.4c509",
-        "type": "inject",
-        "z": "653805bf.2d2784",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 300,
-        "wires": [
-            [
-                "2c24bff8.5d5fb"
-            ]
-        ]
-    },
-    {
-        "id": "1606c311.639f3d",
-        "type": "inject",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 120,
-        "wires": [
-            [
-                "6fad44a5.d5f544"
-            ]
-        ]
-    },
-    {
-        "id": "6fad44a5.d5f544",
-        "type": "function",
-        "z": "c70ec85f.ffbc3",
-        "name": "Fields",
-        "func": "msg.payload = {\n  numValue: 123.0,\n  strValue: \"message\",\n  floatValue: Math.random() * 10,\n  booleanValue: true,\n  //time: new Date(\"2020-07-15T12:00:00Z\")\n}\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 310,
-        "y": 120,
-        "wires": [
-            [
-                "a57b64be.670488"
-            ]
-        ]
-    },
-    {
-        "id": "d390a898.f747a",
-        "type": "catch",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "scope": [
-            "61db7932.0bc2b8"
-        ],
-        "uncaught": false,
-        "x": 110,
-        "y": 380,
-        "wires": [
-            [
-                "2fb394b6.0d2684"
-            ]
-        ]
-    },
-    {
-        "id": "2fb394b6.0d2684",
-        "type": "debug",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 300,
-        "y": 380,
-        "wires": []
-    },
-    {
-        "id": "d9f0ebfc.ecfec8",
-        "type": "inject",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "props": [
-            {
-                "p": "payload",
-                "v": "",
-                "vt": "date"
-            },
-            {
-                "p": "topic",
-                "v": "",
-                "vt": "string"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 60,
-        "wires": [
-            [
-                "c555c3a0.204c58"
-            ]
-        ]
-    },
-    {
-        "id": "c555c3a0.204c58",
-        "type": "function",
-        "z": "c70ec85f.ffbc3",
-        "name": "Single Value",
-        "func": "msg.payload = Math.random() * 10;\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 330,
-        "y": 60,
-        "wires": [
-            [
-                "f5a4befd.56d75"
-            ]
-        ]
-    },
-    {
-        "id": "f35e5815.9ac48",
-        "type": "inject",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 180,
-        "wires": [
-            [
-                "cc6a2a67.5edc28"
-            ]
-        ]
-    },
-    {
-        "id": "cc6a2a67.5edc28",
-        "type": "function",
-        "z": "c70ec85f.ffbc3",
-        "name": "Fields and Tags",
-        "func": "msg.payload = [{\n  numValue: 12,\n  randomValue: Math.random() * 10,\n  strValue: \"message2\",\n  //time: new Date(\"2020-07-09T16:00:00Z\")\n},\n{\n  tag1: \"sensor1\",\n  tag2: \"device2\"\n}];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 340,
-        "y": 180,
-        "wires": [
-            [
-                "42816c54.99f794"
-            ]
-        ]
-    },
-    {
-        "id": "cab64da3.ec089",
-        "type": "inject",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 240,
-        "wires": [
-            [
-                "45dc1b5a.7ab1d4"
-            ]
-        ]
-    },
-    {
-        "id": "45dc1b5a.7ab1d4",
-        "type": "function",
-        "z": "c70ec85f.ffbc3",
-        "name": "multiple readings",
-        "func": "msg.payload = [\n  [{\n    numValue: 10,\n    randomValue: Math.random() * 10,\n    strValue: \"message1\",\n    time: new Date(\"2020-07-16T13:00:02Z\")\n  },\n  {\n    tag1: \"sensor1\",\n    tag2: \"device2\"\n  }],\n  [{\n    numValue: 20,\n    randomValue: Math.random() * 10,\n    strValue: \"message2\",\n    time: new Date(\"2020-07-16T13:00:03Z\")\n  },\n  {\n    tag1: \"sensor2\",\n    tag2: \"device1\"\n  }]\n];\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "x": 350,
-        "y": 240,
-        "wires": [
-            [
-                "3c9f8227.c549de"
-            ]
-        ]
-    },
-    {
-        "id": "3e760db.d141d72",
-        "type": "debug",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "x": 930,
-        "y": 300,
-        "wires": []
-    },
-    {
-        "id": "6d054c00.b726dc",
-        "type": "inject",
-        "z": "c70ec85f.ffbc3",
-        "name": "",
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 140,
-        "y": 300,
-        "wires": [
-            [
-                "de82c653.cd498"
-            ]
-        ]
-    },
-    {
-        "id": "f5a4befd.56d75",
-        "type": "influxdb 2 out",
-        "z": "c70ec85f.ffbc3",
-        "influxdb": "3dcd3c8e.fe9b24",
-        "org": "my-org",
-        "bucket": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "name": "",
-        "x": 650,
-        "y": 60,
-        "wires": []
-    },
-    {
-        "id": "a57b64be.670488",
-        "type": "influxdb 2 out",
-        "z": "c70ec85f.ffbc3",
-        "influxdb": "3dcd3c8e.fe9b24",
-        "org": "my-org",
-        "bucket": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "name": "",
-        "x": 650,
-        "y": 120,
-        "wires": []
-    },
-    {
-        "id": "42816c54.99f794",
-        "type": "influxdb 2 out",
-        "z": "c70ec85f.ffbc3",
-        "influxdb": "3dcd3c8e.fe9b24",
-        "org": "my-org",
-        "bucket": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "name": "",
-        "x": 650,
-        "y": 180,
-        "wires": []
-    },
-    {
-        "id": "3c9f8227.c549de",
-        "type": "influxdb 2 out",
-        "z": "c70ec85f.ffbc3",
-        "influxdb": "3dcd3c8e.fe9b24",
-        "org": "my-org",
-        "bucket": "test",
-        "measurement": "test",
-        "precision": "ms",
-        "name": "",
-        "x": 650,
-        "y": 240,
-        "wires": []
-    },
-    {
-        "id": "de82c653.cd498",
-        "type": "influxdb 2 in",
-        "z": "c70ec85f.ffbc3",
-        "influxdb": "3dcd3c8e.fe9b24",
-        "org": "my-org",
-        "query": "from(bucket: \"test\") |> range(start: -1m, stop: 1h)",
-        "name": "",
-        "x": 500,
-        "y": 300,
-        "wires": [
-            [
-                "3e760db.d141d72"
-            ]
-        ]
-    }
+  {
+    "id": "c535e74d.ab40f",
+    "type": "tab",
+    "label": "InfluxDB",
+    "disabled": false,
+    "info": ""
+  },
+  {
+    "id": "c3d8cdf2.4ce0b",
+    "type": "tab",
+    "label": "Performance test",
+    "disabled": false,
+    "info": ""
+  },
+  {
+    "id": "d50d0c9f.31e858",
+    "type": "tls-config",
+    "z": "",
+    "name": "",
+    "cert": "",
+    "key": "",
+    "ca": "",
+    "certname": "influxdb-selfsigned.crt",
+    "keyname": "influxdb-selfsigned.key",
+    "caname": "",
+    "servername": "",
+    "verifyservercert": false
+  },
+  {
+    "id": "dc66afc1.46c418",
+    "type": "influxdb",
+    "z": "",
+    "hostname": "127.0.0.1",
+    "port": "8086",
+    "protocol": "http",
+    "database": "test",
+    "name": "",
+    "usetls": true,
+    "tls": "d50d0c9f.31e858",
+    "influxdbVersion": "1.8",
+    "url": "http://localhost:8086"
+  },
+  {
+    "id": "2ff2a476.a6d2ec",
+    "type": "influxdb",
+    "z": "",
+    "hostname": "127.0.0.1",
+    "port": "8086",
+    "protocol": "http",
+    "database": "database",
+    "name": "",
+    "usetls": false,
+    "tls": "d50d0c9f.31e858",
+    "influxdbVersion": "1.8 flux",
+    "url": "https://localhost:8086"
+  },
+  {
+    "id": "5d7e54ca.019d44",
+    "type": "influxdb",
+    "z": "",
+    "hostname": "127.0.0.1",
+    "port": "8086",
+    "protocol": "http",
+    "database": "database",
+    "name": "",
+    "usetls": false,
+    "tls": "d50d0c9f.31e858",
+    "influxdbVersion": "2.0",
+    "url": "https://localhost:9999"
+  },
+  {
+    "id": "9b2d89a5.d4115",
+    "type": "influxdb in",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "query": "SELECT * from test",
+    "rawOutput": false,
+    "precision": "",
+    "retentionPolicy": "",
+    "org": "my-org",
+    "x": 420,
+    "y": 380,
+    "wires": [
+      [
+        "3b6c3337.5c09e4"
+      ]
+    ]
+  },
+  {
+    "id": "4453ee9d.5a00b",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 380,
+    "wires": [
+      [
+        "9b2d89a5.d4115"
+      ]
+    ]
+  },
+  {
+    "id": "3b6c3337.5c09e4",
+    "type": "debug",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "x": 710,
+    "y": 380,
+    "wires": []
+  },
+  {
+    "id": "261c594a.45d5be",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": "",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 100,
+    "wires": [
+      [
+        "804662c1.2b9cc"
+      ]
+    ]
+  },
+  {
+    "id": "804662c1.2b9cc",
+    "type": "function",
+    "z": "c535e74d.ab40f",
+    "name": "Fields",
+    "func": "msg.payload = {\n    numValue: 123.0,\n    strValue: \"message\",\n    randomValue: Math.random()*10\n}\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 270,
+    "y": 100,
+    "wires": [
+      [
+        "b688fcc3.f8735"
+      ]
+    ]
+  },
+  {
+    "id": "b688fcc3.f8735",
+    "type": "influxdb out",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "measurement": "test",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "database": "test",
+    "precisionV18FluxV20": "ms",
+    "retentionPolicyV18Flux": "",
+    "org": "my-org",
+    "bucket": "test",
+    "x": 610,
+    "y": 100,
+    "wires": []
+  },
+  {
+    "id": "546a21e7.01fa58",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 160,
+    "wires": [
+      [
+        "62da39df.2abfa"
+      ]
+    ]
+  },
+  {
+    "id": "62da39df.2abfa",
+    "type": "function",
+    "z": "c535e74d.ab40f",
+    "name": "Fields and Tags",
+    "func": "msg.payload = [{\n    numValue: 12,\n    randomValue: Math.random()*10,\n    strValue: \"message2\"\n},\n{\n    tag1:\"sensor1\",\n    tag2:\"device2\"\n}];\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 300,
+    "y": 160,
+    "wires": [
+      [
+        "27c795a.196d66a"
+      ]
+    ]
+  },
+  {
+    "id": "27c795a.196d66a",
+    "type": "influxdb out",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "measurement": "test",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "database": "test",
+    "precisionV18FluxV20": "ms",
+    "retentionPolicyV18Flux": "",
+    "org": "my-org",
+    "bucket": "test",
+    "x": 610,
+    "y": 160,
+    "wires": []
+  },
+  {
+    "id": "8f13494c.697558",
+    "type": "function",
+    "z": "c535e74d.ab40f",
+    "name": "multiple readings",
+    "func": "msg.payload = [\n    [{\n        numValue: 10,\n        randomValue: Math.random()*10,\n        strValue: \"message1\",\n        time: new Date(\"2020-09-10T15:00:00Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }],\n    [{\n        numValue: 20,\n        randomValue: Math.random()*10,\n        strValue: \"message2\",\n        time: new Date(\"2020-09-10T17:00:01Z\").getTime()\n    },\n    {\n        tag1:\"sensor1\",\n        tag2:\"device2\"\n    }]\n];\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 310,
+    "y": 220,
+    "wires": [
+      [
+        "2c381ae5.7bd8b6"
+      ]
+    ]
+  },
+  {
+    "id": "20fa01c1.44ad3e",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 116,
+    "y": 220,
+    "wires": [
+      [
+        "8f13494c.697558"
+      ]
+    ]
+  },
+  {
+    "id": "2c381ae5.7bd8b6",
+    "type": "influxdb out",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "measurement": "test",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "database": "test",
+    "precisionV18FluxV20": "ms",
+    "retentionPolicyV18Flux": "",
+    "org": "my-org",
+    "bucket": "test",
+    "x": 610,
+    "y": 220,
+    "wires": []
+  },
+  {
+    "id": "6d00eb8f.166744",
+    "type": "function",
+    "z": "c535e74d.ab40f",
+    "name": "multiple measurement points",
+    "func": "msg.payload = [\n    {\n        measurement: \"weather_sensor\",\n        fields: {\n            temp: 5.5,\n            light: 678,\n            humidity: 51\n        },\n        tags:{\n            location:\"garden\"\n        },\n        timestamp: new Date()\n    },\n    {\n        measurement: \"alarm_sensor\",\n        fields: {\n            proximity: 999,\n            temp: 19.5\n        },\n        tags:{\n            location:\"home\"\n        },\n        timestamp: new Date()\n    }\n];\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 340,
+    "y": 280,
+    "wires": [
+      [
+        "7dd0ab77.6f1574"
+      ]
+    ]
+  },
+  {
+    "id": "a503f338.ea1368",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 280,
+    "wires": [
+      [
+        "6d00eb8f.166744"
+      ]
+    ]
+  },
+  {
+    "id": "7dd0ab77.6f1574",
+    "type": "influxdb batch",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "name": "",
+    "x": 640,
+    "y": 280,
+    "wires": []
+  },
+  {
+    "id": "4b914805.49fa",
+    "type": "configurable interval",
+    "z": "c3d8cdf2.4ce0b",
+    "d": true,
+    "name": "configurable interval",
+    "interval": "1",
+    "onstart": false,
+    "do_enable": true,
+    "msg": "ping",
+    "showstatus": true,
+    "unit": "milliseconds",
+    "statusformat": "YYYY-MM-D HH:mm:ss",
+    "x": 140,
+    "y": 60,
+    "wires": [
+      [
+        "b5406554.2f7e98"
+      ]
+    ]
+  },
+  {
+    "id": "b5406554.2f7e98",
+    "type": "function",
+    "z": "c3d8cdf2.4ce0b",
+    "name": "Fields",
+    "func": "msg.payload = {\n    randomValue: Math.random()*10\n}\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 370,
+    "y": 60,
+    "wires": [
+      [
+        "6d85462a.f2af18"
+      ]
+    ]
+  },
+  {
+    "id": "6d85462a.f2af18",
+    "type": "influxdb out",
+    "z": "c3d8cdf2.4ce0b",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "measurement": "test",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "database": "test",
+    "precisionV18FluxV20": "ms",
+    "retentionPolicyV18Flux": "",
+    "org": "my-org",
+    "bucket": "test",
+    "x": 630,
+    "y": 60,
+    "wires": []
+  },
+  {
+    "id": "7d7eb0f3.363b38",
+    "type": "influxdb in",
+    "z": "c535e74d.ab40f",
+    "influxdb": "2ff2a476.a6d2ec",
+    "name": "",
+    "query": "from(bucket: \"test/autogen\") |> range(start: -1m, stop: 1h)",
+    "rawOutput": false,
+    "precision": "",
+    "retentionPolicy": "",
+    "org": "my-org",
+    "x": 560,
+    "y": 440,
+    "wires": [
+      [
+        "98becea7.b984a8"
+      ]
+    ]
+  },
+  {
+    "id": "b000113c.7e0e2",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 440,
+    "wires": [
+      [
+        "7d7eb0f3.363b38"
+      ]
+    ]
+  },
+  {
+    "id": "98becea7.b984a8",
+    "type": "debug",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "x": 1010,
+    "y": 440,
+    "wires": []
+  },
+  {
+    "id": "ebcd25d5.a1e6e8",
+    "type": "influxdb in",
+    "z": "c535e74d.ab40f",
+    "influxdb": "5d7e54ca.019d44",
+    "name": "",
+    "query": "from(bucket: \"test\") |> range(start: -1m, stop: 1h)",
+    "rawOutput": false,
+    "precision": "",
+    "retentionPolicy": "",
+    "org": "my-org",
+    "x": 520,
+    "y": 500,
+    "wires": [
+      [
+        "62b2743e.dcd45c"
+      ]
+    ]
+  },
+  {
+    "id": "57c8251c.8b59fc",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 500,
+    "wires": [
+      [
+        "ebcd25d5.a1e6e8"
+      ]
+    ]
+  },
+  {
+    "id": "62b2743e.dcd45c",
+    "type": "debug",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "false",
+    "x": 930,
+    "y": 500,
+    "wires": []
+  },
+  {
+    "id": "b00cb3d6.fff338",
+    "type": "inject",
+    "z": "c535e74d.ab40f",
+    "name": "",
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": "",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 120,
+    "y": 40,
+    "wires": [
+      [
+        "64032201.e9b8c4"
+      ]
+    ]
+  },
+  {
+    "id": "64032201.e9b8c4",
+    "type": "function",
+    "z": "c535e74d.ab40f",
+    "name": "Value",
+    "func": "msg.payload = Math.random()*10;\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "x": 270,
+    "y": 40,
+    "wires": [
+      [
+        "9f4686a0.88a5e"
+      ]
+    ]
+  },
+  {
+    "id": "9f4686a0.88a5e",
+    "type": "influxdb out",
+    "z": "c535e74d.ab40f",
+    "influxdb": "dc66afc1.46c418",
+    "name": "",
+    "measurement": "test",
+    "precision": "ms",
+    "retentionPolicy": "",
+    "database": "test",
+    "precisionV18FluxV20": "ms",
+    "retentionPolicyV18Flux": "",
+    "org": "my-org",
+    "bucket": "test",
+    "x": 610,
+    "y": 40,
+    "wires": []
+  }
 ]


### PR DESCRIPTION
It supports:
- InfluxDB 2.0 using InfluxDB 2.0 API
- InfluxDB 1.8+ Flux (fluxlang) using the 2.0 compatibility API

These are the changes introduced in the pull request:
- Created categories for the different nodes. There is one category for the 1.X nodes, a second category for 1.8+ nodes (using Flux) and a third category for the 2.0 nodes. See image below:

![image](https://user-images.githubusercontent.com/2398027/87885777-41c9ee00-ca18-11ea-8d57-75df25f65743.png)

- TLS standard Node-RED nodes are not used for the new nodes. Instead of that, the full URL has to be added to the configuration nodes. This means that to use SSL, Node-RED certs have to be properly configured. Otherwise, Node-RED has to be started up with the next command: `NODE_TLS_REJECT_UNAUTHORIZED=0 node-red`

- A Docker compose file has been added to test all the nodes, using the updated test-flows/test-flows.json file. This file starts the InfluxDB 1.8+ and Chronograf services, and the InfluxDB 2.0 service

- Updated the README.md files

- The nodes have been tested with InfluxDB 1.8+ and InfluxDB 2.0 Beta