### PR TITLE
Use of TLS-config node also for Influx 1.8-Flux and 2.0

### DIFF
--- a/influxdb.html
+++ b/influxdb.html
@@ -37,14 +37,10 @@
         <label for="node-config-input-token"><i class="fa fa-lock"></i> <span data-i18n="influxdb.label.token"></span></label>
         <input type="password" id="node-config-input-token">
     </div>
-    <div class="form-row" id="node-config-row-rejectUnauthorized">
-        <input type="checkbox" id="node-config-input-rejectUnauthorized" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-config-input-rejectUnauthorized" style="width: auto" data-i18n="influxdb.label.reject-unauthorized"></label>
-    </div>
     <div class="form-row" id="node-config-row-enableSecureConnection">
         <input type="checkbox" id="node-config-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-config-input-usetls" style="width: auto" data-i18n="influxdb.label.use-tls"></label>
-        <div id="node-config-row-tls" class="hide">
+        <div id="node-config-row-tls">
             <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-config-input-tls"><span data-i18n="influxdb.label.tls-config"></span></label>
             <input style="width: 300px;" type="text" id="node-config-input-tls">
         </div>
@@ -85,7 +81,6 @@
                     return true;
                 }
             },
-            rejectUnauthorized: {value: true}
         },
         credentials: {
             username: {type: "text"},
@@ -117,8 +112,6 @@
                 $("#node-config-row-username").show();
                 $("#node-config-row-password").show();
                 $("#node-config-row-token").hide();
-                $("#node-config-row-rejectUnauthorized").hide();   
-                $("#node-config-row-enableSecureConnection").show();                
             }
 
             function update18FluxOptions() {                
@@ -128,8 +121,6 @@
                 $("#node-config-row-username").show();
                 $("#node-config-row-password").show();
                 $("#node-config-row-token").hide();
-                $("#node-config-row-rejectUnauthorized").show();   
-                $("#node-config-row-enableSecureConnection").hide();   
             }
 
             function update20Options() {                
@@ -139,14 +130,17 @@
                 $("#node-config-row-username").hide();
                 $("#node-config-row-password").hide();
                 $("#node-config-row-token").show();
-                $("#node-config-row-rejectUnauthorized").show();   
-                $("#node-config-row-enableSecureConnection").hide();  
             }
 
             $("#node-config-input-influxdbVersion").change(function () {
                 let selected = $("#node-config-input-influxdbVersion option:selected").val();
 
-                switch (selected) {
+                    updateTLSOptions();
+                    $("#node-config-input-usetls").on("click", function () {
+                        updateTLSOptions();
+                    });
+
+                    switch (selected) {
                     case '1.8-flux':
                         update18FluxOptions();
                         break;
@@ -155,10 +149,6 @@
                         break;
                     default:    // 1.x
                         update18Options();
-                        updateTLSOptions();
-                        $("#node-config-input-usetls").on("click", function () {
-                            updateTLSOptions();
-                        });
                 }   
             });
             // if version not set assume 1.x to support older flows

--- a/influxdb.js
+++ b/influxdb.js
@@ -61,11 +61,13 @@ module.exports = function (RED) {
 
             clientOptions = {
                 url: n.url,
-                key: this.hostOptions.key,
-                cert: this.hostOptions.cert,
-                ca: this.hostOptions.ca,
-                rejectUnauthorized: this.hostOptions.rejectUnauthorized,
                 token
+            }
+            if (this.usetls && n.tls) {
+                clientOptions["key"] = this.hostOptions.key;
+                clientOptions["cert"] = this.hostOptions.cert;
+                clientOptions["ca"] = this.hostOptions.ca;
+                clientOptions["rejectUnauthorized"] = this.hostOptions.rejectUnauthorized;
             }
             this.client = new InfluxDB(clientOptions);
         }

--- a/influxdb.js
+++ b/influxdb.js
@@ -25,22 +25,23 @@ module.exports = function (RED) {
             n.influxdbVersion = VERSION_1X;
         }
 
+        this.usetls = n.usetls;
+        if (typeof this.usetls === 'undefined') {
+            this.usetls = false;
+        }
+        // for backward compatibility with old 'protocol' setting
+        if (n.protocol === 'https') {
+            this.usetls = true;
+        }
+        if (this.usetls && n.tls) {
+            var tlsNode = RED.nodes.getNode(n.tls);
+            if (tlsNode) {
+                this.hostOptions = {};
+                tlsNode.addTLSOptions(this.hostOptions);
+            }
+        }
+
         if (n.influxdbVersion === VERSION_1X) {
-            this.usetls = n.usetls;
-            if (typeof this.usetls === 'undefined') {
-                this.usetls = false;
-            }
-            // for backward compatibility with old 'protocol' setting
-            if (n.protocol === 'https') {
-                this.usetls = true;
-            }
-            if (this.usetls && n.tls) {
-                var tlsNode = RED.nodes.getNode(n.tls);
-                if (tlsNode) {
-                    this.hostOptions = {};
-                    tlsNode.addTLSOptions(this.hostOptions);
-                }
-            }
             this.client = new Influx.InfluxDB({
                 hosts: [{
                     host: this.hostname,
@@ -60,7 +61,10 @@ module.exports = function (RED) {
 
             clientOptions = {
                 url: n.url,
-                rejectUnauthorized: n.rejectUnauthorized,
+                key: this.hostOptions.key,
+                cert: this.hostOptions.cert,
+                ca: this.hostOptions.ca,
+                rejectUnauthorized: this.hostOptions.rejectUnauthorized,
                 token
             }
             this.client = new InfluxDB(clientOptions);

--- a/locales/en-US/influxdb.json
+++ b/locales/en-US/influxdb.json
@@ -16,7 +16,6 @@
             "version":"Version",
             "url": "URL",
             "token": "Token",
-            "reject-unauthorized": "Verify server certificate",
             "org": "Organization",
             "bucket": "Bucket"
         },

--- a/locales/es-ES/influxdb.json
+++ b/locales/es-ES/influxdb.json
@@ -16,7 +16,6 @@
             "version":"Versión",
             "url": "URL",
             "token": "Token",
-            "reject-unauthorized": "Verificar el certificado del servidor",
             "org": "Organización",
             "bucket": "Bucket"
         },

--- a/test-flows/test-flows.json
+++ b/test-flows/test-flows.json
@@ -1133,8 +1133,7 @@
     "usetls": true,
     "tls": "d50d0c9f.31e858",
     "influxdbVersion": "1.x",
-    "url": "http://localhost:8086",
-    "rejectUnauthorized": false
+    "url": "http://localhost:8086"
   },
   {
     "id": "2ff2a476.a6d2ec",
@@ -1147,8 +1146,7 @@
     "usetls": false,
     "tls": "d50d0c9f.31e858",
     "influxdbVersion": "1.8-flux",
-    "url": "https://localhost:8086",
-    "rejectUnauthorized": false
+    "url": "https://localhost:8086"
   },
   {
     "id": "5d7e54ca.019d44",
@@ -1161,8 +1159,7 @@
     "usetls": false,
     "tls": "d50d0c9f.31e858",
     "influxdbVersion": "2.0",
-    "url": "https://localhost:9999",
-    "rejectUnauthorized": false
+    "url": "https://localhost:9999"
   },
   {
     "id": "d50d0c9f.31e858",


### PR DESCRIPTION
No matter which influxdb version is configured for the server, the user interface is the same and with the same functionality fot TLS connections

They all use TLS-config node: instancies of InfluxDB class are built with data read from TLS-config node

Also, reject-unauthorized is red from that config node, so it is not needed anymore in influxdb node

I think this is a solution for the [question](https://github.com/mblackstock/node-red-contrib-influxdb/pull/63#discussion_r1012770558) raised in #63

Should you consider it is able to be merged, maybe some examples should be changed