### PR TITLE
feature(database) - allow sending database as a parameter

### DIFF
--- a/influxdb.js
+++ b/influxdb.js
@@ -218,6 +218,7 @@ module.exports = function (RED) {
                 }
                 var precision = msg.hasOwnProperty('precision') ? msg.precision : node.precision;
                 var retentionPolicy = msg.hasOwnProperty('retentionPolicy') ? msg.retentionPolicy : node.retentionPolicy;
+                var database = msg.hasOwnProperty('database') ? msg.database : node.database;
 
                 if (precision) {
                     writeOptions.precision = precision;
@@ -225,6 +226,10 @@ module.exports = function (RED) {
 
                 if (retentionPolicy) {
                     writeOptions.retentionPolicy = retentionPolicy;
+                }
+
+                if (database) {
+                    writeOptions.database = database;
                 }
 
                 // format payload to match new writePoints API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-influxdb",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node-RED nodes to save and query data from an influxdb time series database",
   "main": "influxdb.js",
   "scripts": {


### PR DESCRIPTION
I took a look at the InfluxDB client used in this project, and the [`writePoints`](https://node-influx.github.io/class/src/index.js~InfluxDB.html#instance-method-writePoints) function has `database` included in the options, just not in this node-red module.

I've added this option, but as I never worked on a node-red module before, I have no idea how to verify this work.

